### PR TITLE
doc: add LMCache paper collection

### DIFF
--- a/resources/inference.mdx
+++ b/resources/inference.mdx
@@ -16,6 +16,7 @@ description: "LLM Serving、缓存、调度、PD 分离、推测解码与量化"
 
 | 资源 | 类型 | 简介 |
 |------|------|------|
+| [LMCache 技术：计算与存储解耦下的分布式缓存演进](https://mp.weixin.qq.com/s/jt3FP6WoQHDGGNVAKr0wKg) | 论文合集 | 以 LMCache 为主线串联 CacheGen、CacheBlend、TraCT 等相关工作，梳理 KV Cache 压缩、知识融合、传输与分布式缓存系统的演进。 |
 | [Efficient Memory Management for Large Language Model Serving with PagedAttention](https://arxiv.org/abs/2309.06180) | 论文 | 提出 PagedAttention，以分页方式管理非连续 KV Cache，减少内存碎片和冗余复制，是 vLLM 高吞吐 Serving 的核心工作。 |
 | [CacheBlend: Fast Large Language Model Serving for RAG with Cached Knowledge Fusion](https://arxiv.org/abs/2405.16444) | 论文 | 复用不同知识块的 KV Cache，并选择性重算少量 Token 以融合跨块注意力，在保持生成质量的同时降低 RAG 的 TTFT。 |
 


### PR DESCRIPTION
## Summary

- Add **LMCache 技术：计算与存储解耦下的分布式缓存演进** to the Inference resource page.
- Classify the article as a paper collection under **KV Cache**.
- Add a concise Chinese introduction covering the CacheGen, CacheBlend, and TraCT research line.

## Why

This collection provides a focused reading path for understanding how LMCache-related work evolves from KV Cache compression and knowledge fusion to transfer and distributed cache systems.

## Validation

- `git diff --check`
- `mint validate`
- `mint broken-links`
