### PR TITLE
doc: add open source projects and update chapter 15

### DIFF
--- a/books/ai-systems-performance-engineering/chapters/ch15.mdx
+++ b/books/ai-systems-performance-engineering/chapters/ch15.mdx
@@ -2,6 +2,17 @@
 title: "第十五章：多节点大模型推理——并行部署、解码优化与 MoE 路由"
 ---
 
+## 录屏回看
+
+<iframe
+  src="https://player.bilibili.com/player.html?bvid=BV1khuS6qELP&autoplay=0&high_quality=1"
+  width="100%"
+  height="480"
+  scrolling="no"
+  frameBorder="0"
+  allowFullScreen
+/>
+
 ## 本章概要
 
 多节点大模型推理不是单一的并行或加速问题，而是在模型容量、请求负载、硬件拓扑和服务目标共同约束下进行的系统优化。本章依次讨论阶段资源组织、模型静态布局、MoE 运行时执行路径和投机解码，并以 SLO 约束下的 goodput 作为统一评价目标。

--- a/books/ai-systems-performance-engineering/schedule.mdx
+++ b/books/ai-systems-performance-engineering/schedule.mdx
@@ -7,10 +7,10 @@ icon: "calendar"
 
 | 章节 | 日期 | 主讲 | 状态 |
 |------|------|------|------|
-| [第一章：介绍与 AI 系统概览](/books/ai-systems-performance-engineering/chapters/ch01) | 04.19 | 程治玮 | 已完成 |
-| [第二章：AI 系统硬件概览](/books/ai-systems-performance-engineering/chapters/ch02) | 05.24 | 于增辉 | 已完成 |
-| [第三章：GPU 环境下的 OS、Docker 与 Kubernetes 调优](/books/ai-systems-performance-engineering/chapters/ch03) | 07-12 | 程治玮 | 已完成 |
-| [第四章：分布式网络通信调优](/books/ai-systems-performance-engineering/chapters/ch04) | 06.28 | 费翌阳 | 已完成 |
+| [第一章：介绍与 AI 系统概览](/books/ai-systems-performance-engineering/chapters/ch01) | 2026-04-19 | 程治玮 | 已完成 |
+| [第二章：AI 系统硬件概览](/books/ai-systems-performance-engineering/chapters/ch02) | 2026-05-24 | 于增辉 | 已完成 |
+| [第三章：GPU 环境下的 OS、Docker 与 Kubernetes 调优](/books/ai-systems-performance-engineering/chapters/ch03) | 2026-07-12 | 程治玮 | 已完成 |
+| [第四章：分布式网络通信调优](/books/ai-systems-performance-engineering/chapters/ch04) | 2026-06-28 | 费翌阳 | 已完成 |
 | [第五章：基于 GPU 的存储 I/O 优化](/books/ai-systems-performance-engineering/chapters/ch05) | TBD | 黄健峰 | 未开始 |
 | [第六章：GPU 架构、CUDA 编程与最大化占用率](/books/ai-systems-performance-engineering/chapters/ch06) | TBD | TBD | 未开始 |
 | [第七章：GPU 内存访问模式的分析与调优](/books/ai-systems-performance-engineering/chapters/ch07) | TBD | TBD | 未开始 |
@@ -21,7 +21,7 @@ icon: "calendar"
 | [第十二章：动态调度、CUDA Graphs 与设备发起的 Kernel 编排](/books/ai-systems-performance-engineering/chapters/ch12) | TBD | TBD | 未开始 |
 | [第十三章：PyTorch 的分析、调优与扩展](/books/ai-systems-performance-engineering/chapters/ch13) | TBD | TBD | 未开始 |
 | [第十四章：PyTorch 编译器、OpenAI Triton 与 XLA 后端](/books/ai-systems-performance-engineering/chapters/ch14) | TBD | TBD | 未开始 |
-| [第十五章：多节点推理、并行、解码与路由优化](/books/ai-systems-performance-engineering/chapters/ch15) | TBD | TBD | 未开始 |
+| [第十五章：多节点推理、并行、解码与路由优化](/books/ai-systems-performance-engineering/chapters/ch15) | 2026-08-09 | 张文正 | 已完成 |
 | [第十六章：大规模推理的分析、调试与调优](/books/ai-systems-performance-engineering/chapters/ch16) | TBD | TBD | 未开始 |
 | [第十七章：推理中分离式 Prefill 与 Decode 的扩展](/books/ai-systems-performance-engineering/chapters/ch17) | TBD | TBD | 未开始 |
 | [第十八章：高级 Prefill-Decode 与 KV Cache 调优](/books/ai-systems-performance-engineering/chapters/ch18) | TBD | TBD | 未开始 |

--- a/docs.json
+++ b/docs.json
@@ -91,12 +91,6 @@
         "tab": "学习资源",
         "groups": [
           {
-            "group": "概览",
-            "pages": [
-              "resources/index"
-            ]
-          },
-          {
             "group": "主题分类",
             "pages": [
               "resources/llm-foundations",
@@ -106,6 +100,18 @@
               "resources/gpu-programming",
               "resources/performance-analysis",
               "resources/agents"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "开源项目",
+        "groups": [
+          {
+            "group": "主题分类",
+            "pages": [
+              "projects/agents",
+              "projects/cluster-infrastructure"
             ]
           }
         ]

--- a/projects/agents.mdx
+++ b/projects/agents.mdx
@@ -1,0 +1,10 @@
+---
+title: "Agent"
+description: "Agent 框架、运行时与开发工具"
+---
+
+## Agent 框架
+
+| 项目 | 简介 | 参考资料 |
+|------|------|----------|
+| [vercel/eve](https://github.com/vercel/eve) | Vercel 开源的文件系统优先持久化 Agent 框架，通过约定目录组织 Instructions、Tools、Skills、Channels 和 Schedules，方便检查、扩展和运行 Agent 项目。 | [官方文档](https://eve.dev/) |

--- a/projects/cluster-infrastructure.mdx
+++ b/projects/cluster-infrastructure.mdx
@@ -1,0 +1,10 @@
+---
+title: "集群与基础设施"
+description: "GPU 集群配置、资源编排、任务调度与部署自动化"
+---
+
+## 集群配置与验证
+
+| 项目 | 简介 | 参考资料 |
+|------|------|----------|
+| [NVIDIA/aicr](https://github.com/NVIDIA/aicr) | 面向 GPU Kubernetes 集群的配置生成与验证工具。采集集群状态，并根据云平台、GPU、操作系统和部署目标生成经过验证、可复现的 Helm、Argo CD、Flux 或 Helmfile 配置。 | [官方文档](https://docs.nvidia.com/aicr/overview/introduction/) |


### PR DESCRIPTION
## Summary

- add an **Open Source Projects** tab organized by topic
- add Agent and Cluster & Infrastructure pages with entries for Vercel Eve and NVIDIA AICR
- simplify the Learning Resources navigation so it opens directly to topic pages
- embed the Chapter 15 recording and update its presenter, completion status, and date
- normalize all scheduled dates to the `YYYY-MM-DD` format

## Why

The site needs a scalable, topic-based home for open source AI infrastructure projects. This also keeps the learning-resource navigation focused and brings the Chapter 15 schedule in sync with the published recording.

## User impact

Readers can browse open source projects by topic, follow official reference documentation, and see consistent dates and accurate Chapter 15 session information.

## Test plan

- `jq empty docs.json`
- `git diff --check`
- `mint validate`
- `mint broken-links`
- verified the updated pages in the local Mintlify preview
