### PR TITLE
doc: expand open source inference and Agent catalog

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -110,6 +110,7 @@
           {
             "group": "主题分类",
             "pages": [
+              "projects/inference",
               "projects/agents",
               "projects/cluster-infrastructure"
             ]

--- a/projects/agents.mdx
+++ b/projects/agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent"
-description: "Agent 框架、运行时与开发工具"
+description: "Agent 框架、Sandbox、运行时与开发工具"
 ---
 
 ## Agent 框架
@@ -8,3 +8,15 @@ description: "Agent 框架、运行时与开发工具"
 | 项目 | 简介 | 参考资料 |
 |------|------|----------|
 | [vercel/eve](https://github.com/vercel/eve) | Vercel 开源的文件系统优先持久化 Agent 框架，通过约定目录组织 Instructions、Tools、Skills、Channels 和 Schedules，方便检查、扩展和运行 Agent 项目。 | [官方文档](https://eve.dev/) |
+
+## Agent Sandbox
+
+| 项目 | 简介 | 参考资料 |
+|------|------|----------|
+| [kvcache-ai/AgentENV](https://github.com/kvcache-ai/AgentENV) | 面向大规模 Agent 环境的分布式运行平台，基于 Firecracker microVM 提供快速启动、暂停、恢复、快照和 Fork，并兼容 E2B API。 | [官方文档](https://kvcache-ai.github.io/AgentENV/latest/) |
+| [opensandbox-group/OpenSandbox](https://github.com/opensandbox-group/OpenSandbox) | 面向 Coding Agent、GUI Agent、评测和 RL 训练的通用 Sandbox 平台，提供统一 API、多语言 SDK，以及 Docker 和 Kubernetes Runtime。 | [官方文档](https://open-sandbox.ai/getting-started/) |
+| [TencentCloud/CubeSandbox](https://github.com/TencentCloud/CubeSandbox) | 基于 RustVMM 与 KVM 的轻量级 Agent Sandbox，支持硬件级隔离、E2B API、快照以及单节点和多节点部署。 | [官方文档](https://cubesandbox.com/guide/introduction.html) |
+| [agent-substrate/substrate](https://github.com/agent-substrate/substrate) | Kubernetes 上的高密度 Agent Runtime，将大量有状态 Actor 复用到较少的 Worker，并提供亚秒级暂停恢复、状态持久化和请求路由。 | [项目说明](https://github.com/agent-substrate/substrate#readme) |
+| [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) | Kubernetes SIG Apps 的 Sandbox CRD 与控制器，为有状态单实例环境提供稳定身份、持久化、生命周期管理和预热池，并将底层隔离交给 gVisor、Kata 等 Runtime。 | [官方文档](https://agent-sandbox.sigs.k8s.io/docs/) |
+| [openkruise/agents](https://github.com/openkruise/agents) | 面向 Kubernetes Agent Sandbox 生命周期管理的 Operator，提供资源池、动态扩缩、休眠与 Checkpoint、会话路由，以及 E2B 和 Kubernetes API。 | [官方文档](https://openkruise.io/kruiseagents/introduction) |
+| [volcano-sh/agentcube](https://github.com/volcano-sh/agentcube) | Volcano 社区面向 Agent 工作负载提出的管理系统，聚焦低延迟调度、有状态休眠恢复、高密度资源利用和命令式执行 API。 | [项目提案](https://github.com/volcano-sh/volcano/issues/4686) |

--- a/projects/inference.mdx
+++ b/projects/inference.mdx
@@ -1,0 +1,10 @@
+---
+title: "推理"
+description: "LLM Serving、KV Cache、调度与推理优化项目"
+---
+
+## KV Cache
+
+| 项目 | 简介 | 参考资料 |
+|------|------|----------|
+| [LMCache/LMCache](https://github.com/LMCache/LMCache) | 面向 LLM 推理的 KV Cache 管理层，可将缓存卸载到 CPU、磁盘或远程存储，并在请求和 Serving 实例之间持久化与复用，减少重复 Prefill 计算并降低首 Token 延迟。 | [官方文档](https://docs.lmcache.ai/) |

--- a/projects/inference.mdx
+++ b/projects/inference.mdx
@@ -8,3 +8,6 @@ description: "LLM Serving、KV Cache、调度与推理优化项目"
 | 项目 | 简介 | 参考资料 |
 |------|------|----------|
 | [LMCache/LMCache](https://github.com/LMCache/LMCache) | 面向 LLM 推理的 KV Cache 管理层，可将缓存卸载到 CPU、磁盘或远程存储，并在请求和 Serving 实例之间持久化与复用，减少重复 Prefill 计算并降低首 Token 延迟。 | [官方文档](https://docs.lmcache.ai/) |
+| [taco-project/FlexKV](https://github.com/taco-project/FlexKV) | 面向大规模 LLM 推理的分布式 KV Cache 系统，提供 CPU、SSD、分布式存储三级缓存、跨节点复用和异步预取，已集成 vLLM、SGLang、TensorRT-LLM 与 Dynamo。 | [使用文档](https://github.com/taco-project/FlexKV#readme) |
+| [kvcache-ai/Mooncake](https://github.com/kvcache-ai/Mooncake) | 提供高性能 Transfer Engine 和分布式 Mooncake Store，更偏向 KV Cache 的传输与存储底座；既可独立使用，也可作为 LMCache 后端。 | [官方文档](https://kvcache-ai.github.io/Mooncake/) |
+| [SGLang HiCache](https://github.com/sgl-project/sglang) | SGLang 内置的分层 KV Cache 系统，在 GPU、CPU 与分布式存储之间缓存和复用 KV 数据，扩展可用缓存容量并减少重复 Prefill。 | [官方文档](https://docs.sglang.io/docs/advanced_features/hicache) |

--- a/projects/inference.mdx
+++ b/projects/inference.mdx
@@ -3,6 +3,23 @@ title: "推理"
 description: "LLM Serving、KV Cache、调度与推理优化项目"
 ---
 
+## 推理引擎
+
+| 项目 | 简介 | 参考资料 |
+|------|------|----------|
+| [vllm-project/vllm](https://github.com/vllm-project/vllm) | 高吞吐、显存高效的 LLM 推理与 Serving 引擎，提供 PagedAttention、连续批处理、分布式推理以及 OpenAI 兼容服务接口。 | [官方文档](https://docs.vllm.ai/) |
+| [sgl-project/sglang](https://github.com/sgl-project/sglang) | 面向语言模型和多模态模型的高性能推理框架，覆盖 RadixAttention、结构化输出、推测解码和分布式 Serving。 | [官方文档](https://docs.sglang.io/) |
+| [NVIDIA/TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM) | 面向 NVIDIA GPU 的 LLM 推理引擎，提供优化 Kernel、量化、In-flight Batching 以及多 GPU、多节点推理能力。 | [官方文档](https://nvidia.github.io/TensorRT-LLM/) |
+
+## 推理平台
+
+| 项目 | 简介 | 参考资料 |
+|------|------|----------|
+| [ai-dynamo/dynamo](https://github.com/ai-dynamo/dynamo) | 面向数据中心级 GPU 集群的分布式推理框架，负责请求路由、Prefill-Decode 分离、Worker 编排和跨节点推理。 | [官方文档](https://docs.nvidia.com/dynamo/latest/) |
+| [llm-d/llm-d](https://github.com/llm-d/llm-d) | Kubernetes 原生的分布式 LLM 推理栈，围绕推理引擎提供智能路由、Prefill-Decode 分离、KV Cache 感知调度和集群部署能力。 | [官方网站](https://www.llm-d.ai/) |
+| [volcano-sh/kthena](https://github.com/volcano-sh/kthena) | Kubernetes 原生 AI Serving 平台，通过声明式资源管理模型服务，并提供推理路由、资源调度与多节点部署能力。 | [官方文档](https://kthena.volcano.sh/docs/intro) |
+| [ome-projects/ome](https://github.com/ome-projects/ome) | 面向 LLM Serving 的 Kubernetes Operator，管理模型生命周期、Serving Runtime、服务部署和 GPU 调度，支持 SGLang、vLLM、TensorRT-LLM 与 Triton。 | [官方文档](https://ome-projects.github.io/ome/docs/overview/) |
+
 ## KV Cache
 
 | 项目 | 简介 | 参考资料 |

--- a/resources/inference.mdx
+++ b/resources/inference.mdx
@@ -19,6 +19,7 @@ description: "LLM Serving、缓存、调度、PD 分离、推测解码与量化"
 | [LMCache 技术：计算与存储解耦下的分布式缓存演进](https://mp.weixin.qq.com/s/jt3FP6WoQHDGGNVAKr0wKg) | 论文合集 | 以 LMCache 为主线串联 CacheGen、CacheBlend、TraCT 等相关工作，梳理 KV Cache 压缩、知识融合、传输与分布式缓存系统的演进。 |
 | [Efficient Memory Management for Large Language Model Serving with PagedAttention](https://arxiv.org/abs/2309.06180) | 论文 | 提出 PagedAttention，以分页方式管理非连续 KV Cache，减少内存碎片和冗余复制，是 vLLM 高吞吐 Serving 的核心工作。 |
 | [CacheBlend: Fast Large Language Model Serving for RAG with Cached Knowledge Fusion](https://arxiv.org/abs/2405.16444) | 论文 | 复用不同知识块的 KV Cache，并选择性重算少量 Token 以融合跨块注意力，在保持生成质量的同时降低 RAG 的 TTFT。 |
+| [SnapKV: LLM Knows What You are Looking for Before Generation](https://arxiv.org/abs/2404.14469) | 论文 | 从提示末尾的观察窗口识别各 Attention Head 关注的位置，仅保留聚类后的重要 KV，在无需微调的情况下压缩长上下文 KV Cache。 |
 
 ## 调度与批处理
 


### PR DESCRIPTION
## Summary

- add dedicated **Inference Engine** and **Inference Platform** sections to the open source project catalog
- add vLLM, SGLang, TensorRT-LLM, NVIDIA Dynamo, llm-d, Kthena, and Open Model Engine
- expand the **KV Cache** section with LMCache, FlexKV, Mooncake, and SGLang HiCache
- add an **Agent Sandbox** section with AgentENV, OpenSandbox, CubeSandbox, Agent Substrate, Kubernetes SIG Agent Sandbox, OpenKruise Agents, and AgentCube
- add the SnapKV paper to the KV Cache learning resources
- link every project to its official documentation or primary project material

## Why

The open source catalog should distinguish execution engines from distributed serving platforms and Agent sandbox infrastructure. The new sections make each project's primary responsibility clear while keeping the topic-based navigation compact.

## User impact

Readers can compare major LLM inference engines, serving platforms, KV cache systems, and Agent sandbox runtimes from focused topic tables with concise descriptions and official references.

## Test plan

- `jq empty docs.json`
- `git diff --check`
- `mint validate`
- `mint broken-links`
- verified all newly added external links return HTTP 200
