### PR TITLE
doc: add interview questions and RL resources

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -116,6 +116,17 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "面试题",
+        "groups": [
+          {
+            "group": "主题分类",
+            "pages": [
+              "interview/inference"
+            ]
+          }
+        ]
       }
     ]
   },

--- a/docs.json
+++ b/docs.json
@@ -95,6 +95,7 @@
             "pages": [
               "resources/llm-foundations",
               "resources/training",
+              "resources/rl",
               "resources/inference",
               "resources/rag",
               "resources/gpu-programming",
@@ -123,7 +124,8 @@
           {
             "group": "主题分类",
             "pages": [
-              "interview/inference"
+              "interview/inference",
+              "interview/intelligent-routing"
             ]
           }
         ]

--- a/interview/inference.mdx
+++ b/interview/inference.mdx
@@ -7,7 +7,7 @@ description: "LLM Serving、模型量化和 KV Cache 面试题"
 
 ### 面试题
 
-> 同一模型采用不同权重精度或 KV Cache 精度时，KV Cache 的显存占用、容量、性能和精度有什么区别？请结合 vLLM 的 `--dtype`、`--quantization` 和 `--kv-cache-dtype` 说明。
+> 同一模型采用不同权重精度或 KV Cache 精度时，KV Cache 的显存占用、容量、性能和精度有什么区别？
 
 ### 核心结论
 

--- a/interview/inference.mdx
+++ b/interview/inference.mdx
@@ -1,0 +1,91 @@
+---
+title: "LLM 推理"
+description: "LLM Serving、模型量化和 KV Cache 面试题"
+---
+
+## KV Cache 与数值精度
+
+### 面试题
+
+> 同一模型采用不同权重精度或 KV Cache 精度时，KV Cache 的显存占用、容量、性能和精度有什么区别？请结合 vLLM 的 `--dtype`、`--quantization` 和 `--kv-cache-dtype` 说明。
+
+### 核心结论
+
+权重精度和 KV Cache 精度是两个独立变量。固定 KV Cache dtype 时，权重精度不会改变单个 token 的 KV Cache 大小；权重量化通过减少模型权重占用，间接为 KV Cache 释放更多显存。KV Cache dtype 则直接决定每个缓存值占用的字节数，同时影响 Attention 的访存量和数值误差。
+
+### 三个参数的控制边界
+
+| 参数 | 控制内容 | 常见参数值 | 对 KV Cache 的影响 |
+|------|----------|------------|--------------------|
+| [`--dtype`](https://docs.vllm.ai/en/latest/configuration/engine_args/#-dtype) | 模型的基础浮点 dtype。未量化模型的浮点权重、普通激活和未量化层使用该 dtype。 | `auto`、`float16`、`bfloat16`、`float32` | `--kv-cache-dtype=auto` 时，KV Cache 跟随模型 dtype；显式设置 KV dtype 后不再由它决定。 |
+| [`--quantization`](https://docs.vllm.ai/en/latest/configuration/engine_args/#-quantization) | 量化方案、量化权重格式以及对应的计算 kernel。 | `awq`、`gptq`、`fp8`、`bitsandbytes` | 不直接改变 KV Cache dtype。权重占用下降后，剩余显存可以分配给更多 KV block。 |
+| [`--kv-cache-dtype`](https://docs.vllm.ai/en/latest/configuration/engine_args/#-kv-cache-dtype) | KV Cache 的存储 dtype。 | `auto`、`float16`、`bfloat16`、`fp8`、`fp8_e4m3`、`fp8_e5m2` | 直接改变单个 token 的 KV Cache 大小、可缓存 token 数和 KV 量化误差。 |
+
+`--quantization` 可以由 checkpoint 的 `quantization_config` 自动识别。表格和命令显式列出该参数，是为了清楚展示权重量化与 KV Cache 量化的边界。`--quantization awq` 通常表示加载已经完成 AWQ 量化的 checkpoint，并不会在服务启动时完成需要校准数据的 AWQ 量化。
+
+### KV Cache 显存计算
+
+标准 MHA 或 GQA 模型中，单个序列的 KV Cache 大小近似为：
+
+```text
+M_KV = 2 × L × T × H_KV × D_H × bytes/value
+```
+
+`2` 表示 Key 和 Value，`L` 是 Transformer 层数，`T` 是缓存 token 数，`H_KV` 是 KV head 数，`D_H` 是每个 head 的维度。同一模型和相同 token 数下，只有 `bytes/value` 会随 KV Cache dtype 直接变化。
+
+| KV Cache dtype | 每个值占用 | 相对显存 | 相同显存下的理论 token 容量 |
+|----------------|------------|----------|--------------------------------|
+| FP16 | 2 bytes | 100% | 1× |
+| BF16 | 2 bytes | 100% | 1× |
+| FP8 | 1 byte | 约 50% | 约 2× |
+
+FP16 和 BF16 的显存占用相同，但数值特性不同。FP16 的尾数精度更高，BF16 的指数范围更大。FP8 将 KV Cache 主体显存降到约一半；实际容量提升会受到 scale、内存对齐、block 碎片和运行时预留空间影响，因此不一定达到严格的 2 倍。
+
+### 权重精度变化
+
+固定 `--kv-cache-dtype` 后，BF16、FP8 或 AWQ INT4 权重使用相同的 KV Cache 形状和存储 dtype，因此单个 token 的 KV Cache 显存不变。低精度权重减少常驻模型显存，vLLM 可以在相同 GPU 显存预算中分配更多 KV block，从而提高最大上下文容量或并发量。
+
+权重量化仍会改变 KV Cache 中保存的数值。每层的 Key 和 Value 由 `K = XW_K` 和 `V = XW_V` 计算；`W_K`、`W_V` 的量化误差会传递到 K/V。此时缓存布局和字节数不变，数值结果可能与原始 BF16/FP16 模型不同。
+
+权重量化主要影响模型 GEMM 和权重读取。AWQ、GPTQ 或 FP8 是否更快取决于 GPU、batch size 和量化 kernel；权重变小不代表端到端吞吐按相同比例提高。固定 KV dtype 时，Attention 读取历史 KV Cache 的字节数不会因为权重量化而下降。
+
+### KV Cache 精度变化
+
+将 KV Cache 从 BF16/FP16 改为 FP8，会直接减少 Attention 在 decode 阶段读取历史 K/V 的数据量。长上下文或高并发场景通常更容易获得容量和吞吐收益；量化、反量化以及 backend 支持会影响实际延迟。部分 Attention backend 可以直接在 FP8 域执行更多计算，其他实现可能需要转换回更高精度。
+
+FP8 KV Cache 会在权重量化误差之外增加缓存量化误差。K/V scale 的粒度和校准方式会直接影响生成质量。vLLM 的 [FP8 KV Cache 文档](https://docs.vllm.ai/en/latest/features/quantization/quantized_kvcache/)介绍了 per-tensor、per-attention-head scale 以及使用校准数据生成 scale 的方式。需要通过目标模型、目标数据集和目标上下文长度上的质量评测决定是否启用。
+
+### 典型配置
+
+| 场景 | `--quantization` | `--dtype` | `--kv-cache-dtype` | 结果 |
+|------|------------------|-----------|--------------------|------|
+| 未量化 FP16 基线 | 省略 | `float16` | `float16` | 浮点权重和激活为 FP16，KV Cache 为 FP16。 |
+| 未量化 BF16 基线 | 省略 | `bfloat16` | `bfloat16` | 浮点权重、激活和 KV Cache 为 BF16；KV 容量与 FP16 相同。 |
+| AWQ W4A16，FP16 KV | `awq` | `float16` | `float16` | 量化层权重为 AWQ INT4，普通激活和 KV Cache 为 FP16。权重释放显存，但单 token KV 大小不变。 |
+| AWQ W4A16，FP8 KV | `awq` | `float16` | `fp8` | AWQ 减少权重显存，FP8 直接减少单 token KV 显存，两种收益叠加。 |
+| FP8 权重，BF16 KV | `fp8` | `bfloat16` | `bfloat16` | 量化层使用 FP8 方案，普通浮点张量和 KV Cache 使用 BF16；单 token KV 大小仍为 2 bytes/value。 |
+
+AWQ 与 FP16 KV Cache 的完整命令如下。模型路径需要指向已经完成 AWQ 量化的 checkpoint：
+
+```bash
+vllm serve /path/to/model-awq \
+  --quantization awq \
+  --dtype float16 \
+  --kv-cache-dtype float16
+```
+
+这组参数表示 AWQ INT4 权重、FP16 普通激活和 FP16 KV Cache。`--quantization awq` 不会把 KV Cache 转换成 INT4；如需压缩 KV Cache，需要单独设置 `--kv-cache-dtype fp8`。
+
+### 对比实验的控制变量
+
+比较权重精度时，应固定模型架构、请求长度、并发量和 `--kv-cache-dtype`，分别改变 `--dtype` 或 `--quantization`。比较 KV Cache 精度时，应固定 checkpoint、`--dtype`、`--quantization` 和工作负载，只改变 `--kv-cache-dtype`。否则无法判断显存、性能或生成质量的变化来自权重量化还是 KV Cache 量化。
+
+### 参考文档
+
+| 文档 | 内容 |
+|------|------|
+| [vLLM `--dtype`](https://docs.vllm.ai/en/latest/configuration/engine_args/#-dtype) | 基础浮点权重和激活 dtype。 |
+| [vLLM `--quantization`](https://docs.vllm.ai/en/latest/configuration/engine_args/#-quantization) | 权重量化方法与 checkpoint 自动识别规则。 |
+| [vLLM `--kv-cache-dtype`](https://docs.vllm.ai/en/latest/configuration/engine_args/#-kv-cache-dtype) | KV Cache 存储 dtype 和支持格式。 |
+| [vLLM Quantized KV Cache](https://docs.vllm.ai/en/latest/features/quantization/quantized_kvcache/) | FP8 KV Cache、scale 和校准方式。 |
+| [LLM Compressor AWQ](https://docs.vllm.ai/projects/llm-compressor/en/latest/examples/awq/) | AWQ 校准、量化和 checkpoint 保存示例。 |

--- a/interview/inference.mdx
+++ b/interview/inference.mdx
@@ -1,5 +1,5 @@
 ---
-title: "LLM 推理"
+title: "推理"
 description: "LLM Serving、模型量化和 KV Cache 面试题"
 ---
 

--- a/interview/inference.mdx
+++ b/interview/inference.mdx
@@ -5,87 +5,70 @@ description: "LLM Serving、模型量化和 KV Cache 面试题"
 
 ## KV Cache 与数值精度
 
-### 面试题
+同一模型采用不同权重精度或 KV Cache 精度时，KV Cache 的显存占用、容量、性能和精度有什么区别？
 
-> 同一模型采用不同权重精度或 KV Cache 精度时，KV Cache 的显存占用、容量、性能和精度有什么区别？
+### 控制精度的三个参数
 
-### 核心结论
-
-权重精度和 KV Cache 精度是两个独立变量。固定 KV Cache dtype 时，权重精度不会改变单个 token 的 KV Cache 大小；权重量化通过减少模型权重占用，间接为 KV Cache 释放更多显存。KV Cache dtype 则直接决定每个缓存值占用的字节数，同时影响 Attention 的访存量和数值误差。
-
-### 三个参数的控制边界
+讨论“不同精度”时，需要先区分精度作用在哪类数据上。vLLM 使用下面三个参数分别配置模型的基础浮点精度、权重量化方法和 KV Cache 精度。它们控制的对象不同，对 KV Cache 的影响也不同。
 
 | 参数 | 控制内容 | 常见参数值 | 对 KV Cache 的影响 |
 |------|----------|------------|--------------------|
-| [`--dtype`](https://docs.vllm.ai/en/latest/configuration/engine_args/#-dtype) | 模型的基础浮点 dtype。未量化模型的浮点权重、普通激活和未量化层使用该 dtype。 | `auto`、`float16`、`bfloat16`、`float32` | `--kv-cache-dtype=auto` 时，KV Cache 跟随模型 dtype；显式设置 KV dtype 后不再由它决定。 |
-| [`--quantization`](https://docs.vllm.ai/en/latest/configuration/engine_args/#-quantization) | 量化方案、量化权重格式以及对应的计算 kernel。 | `awq`、`gptq`、`fp8`、`bitsandbytes` | 不直接改变 KV Cache dtype。权重占用下降后，剩余显存可以分配给更多 KV block。 |
-| [`--kv-cache-dtype`](https://docs.vllm.ai/en/latest/configuration/engine_args/#-kv-cache-dtype) | KV Cache 的存储 dtype。 | `auto`、`float16`、`bfloat16`、`fp8`、`fp8_e4m3`、`fp8_e5m2` | 直接改变单个 token 的 KV Cache 大小、可缓存 token 数和 KV 量化误差。 |
+| [`--dtype`](https://docs.vllm.ai/en/latest/configuration/engine_args/#-dtype) | 模型运行时的基础浮点精度。未量化权重和激活使用该 dtype；量化权重格式由 `--quantization` 控制 | `auto`、`float16`、`bfloat16`、`float32` | 仅当 `--kv-cache-dtype=auto` 时，KV Cache 才跟随模型 dtype |
+| [`--quantization`](https://docs.vllm.ai/en/latest/configuration/engine_args/#-quantization) | 权重量化方法 | `awq`、`gptq`、`fp8`、`bitsandbytes` | 不直接改变 KV Cache 精度和单个 token 的 KV Cache 大小；权重显存减少后，可以增加 KV Cache 总容量 |
+| [`--kv-cache-dtype`](https://docs.vllm.ai/en/latest/configuration/engine_args/#-kv-cache-dtype) | KV Cache 精度 | `auto`、`float16`、`bfloat16`、`fp8`、`fp8_e4m3`、`fp8_e5m2` | 直接影响单个 token 的 KV Cache 大小、容量和量化误差 |
 
-`--quantization` 可以由 checkpoint 的 `quantization_config` 自动识别。表格和命令显式列出该参数，是为了清楚展示权重量化与 KV Cache 量化的边界。`--quantization awq` 通常表示加载已经完成 AWQ 量化的 checkpoint，并不会在服务启动时完成需要校准数据的 AWQ 量化。
+未显式设置 `--quantization` 时，vLLM 会读取 checkpoint 中的 `quantization_config`。`--quantization awq` 通常用于加载已经完成 AWQ 量化的 checkpoint，不会在服务启动时执行需要校准数据的 AWQ 量化。
+
+**以 `--quantization awq --dtype float16` 为例：**
+
+- **量化层权重**：AWQ W4A16 通常以 Linear 层为量化目标，将其权重保存为 INT4，并按组保存 scale；非对称量化还会保存 zero point。在常见 Llama 类模型中，这些层包括 Attention 的 `q_proj`、`k_proj`、`v_proj`、`o_proj` 和 MLP 的 `gate_proj`、`up_proj`、`down_proj`。
+
+<Accordion title="量化 scale 和 zero point 是什么？">
+  INT4 只能保存 `0～15` 这样的离散整数。scale 表示相邻两个量化值之间的步长，zero point 表示浮点数 `0` 对应哪个 INT4 数值。量化 kernel 使用下面的公式近似还原浮点权重：
+
+  ```text
+  浮点权重 ≈ (INT4 数值 - zero point) × scale
+  ```
+
+  例如：
+
+  ```text
+  INT4 数值 = 12
+  scale = 0.05
+  zero point = 8
+
+  浮点权重 ≈ (12 - 8) × 0.05 = 0.2
+  ```
+
+  通常是一组权重共享一套 scale 和 zero point，例如每 128 个权重为一组，而不是为每个权重分别保存。对称量化一般不需要单独保存 zero point。
+</Accordion>
+
+- **激活**：W4A16 中的 A16 表示激活使用 16 位浮点格式。在这个示例中，`--dtype float16` 使 Linear 层的输入和输出激活使用 FP16。量化 kernel 在矩阵乘法过程中读取 INT4 权重和 scale，不会把整份权重长期展开成 FP16 保存在显存中。
+- **未量化权重**：未被 AWQ 选中或通过 `ignore` 排除的权重仍使用基础浮点 dtype。在本例中，`--dtype float16` 将这些权重设置为 FP16。
 
 ### KV Cache 显存计算
 
-标准 MHA 或 GQA 模型中，单个序列的 KV Cache 大小近似为：
+对于结构统一且 Batch 内序列长度相同的 Decoder-only MHA 或 GQA 模型，KV Cache 主体显存可以用下面的公式估算：
 
 ```text
-M_KV = 2 × L × T × H_KV × D_H × bytes/value
+total_bytes
+= batch_size
+  × sequence_length
+  × num_layers
+  × 2
+  × num_key_value_heads
+  × head_dim
+  × precision_bytes
 ```
 
-`2` 表示 Key 和 Value，`L` 是 Transformer 层数，`T` 是缓存 token 数，`H_KV` 是 KV head 数，`D_H` 是每个 head 的维度。同一模型和相同 token 数下，只有 `bytes/value` 会随 KV Cache dtype 直接变化。
-
-| KV Cache dtype | 每个值占用 | 相对显存 | 相同显存下的理论 token 容量 |
-|----------------|------------|----------|--------------------------------|
-| FP16 | 2 bytes | 100% | 1× |
-| BF16 | 2 bytes | 100% | 1× |
-| FP8 | 1 byte | 约 50% | 约 2× |
-
-FP16 和 BF16 的显存占用相同，但数值特性不同。FP16 的尾数精度更高，BF16 的指数范围更大。FP8 将 KV Cache 主体显存降到约一半；实际容量提升会受到 scale、内存对齐、block 碎片和运行时预留空间影响，因此不一定达到严格的 2 倍。
-
-### 权重精度变化
-
-固定 `--kv-cache-dtype` 后，BF16、FP8 或 AWQ INT4 权重使用相同的 KV Cache 形状和存储 dtype，因此单个 token 的 KV Cache 显存不变。低精度权重减少常驻模型显存，vLLM 可以在相同 GPU 显存预算中分配更多 KV block，从而提高最大上下文容量或并发量。
-
-权重量化仍会改变 KV Cache 中保存的数值。每层的 Key 和 Value 由 `K = XW_K` 和 `V = XW_V` 计算；`W_K`、`W_V` 的量化误差会传递到 K/V。此时缓存布局和字节数不变，数值结果可能与原始 BF16/FP16 模型不同。
-
-权重量化主要影响模型 GEMM 和权重读取。AWQ、GPTQ 或 FP8 是否更快取决于 GPU、batch size 和量化 kernel；权重变小不代表端到端吞吐按相同比例提高。固定 KV dtype 时，Attention 读取历史 KV Cache 的字节数不会因为权重量化而下降。
-
-### KV Cache 精度变化
-
-将 KV Cache 从 BF16/FP16 改为 FP8，会直接减少 Attention 在 decode 阶段读取历史 K/V 的数据量。长上下文或高并发场景通常更容易获得容量和吞吐收益；量化、反量化以及 backend 支持会影响实际延迟。部分 Attention backend 可以直接在 FP8 域执行更多计算，其他实现可能需要转换回更高精度。
-
-FP8 KV Cache 会在权重量化误差之外增加缓存量化误差。K/V scale 的粒度和校准方式会直接影响生成质量。vLLM 的 [FP8 KV Cache 文档](https://docs.vllm.ai/en/latest/features/quantization/quantized_kvcache/)介绍了 per-tensor、per-attention-head scale 以及使用校准数据生成 scale 的方式。需要通过目标模型、目标数据集和目标上下文长度上的质量评测决定是否启用。
-
-### 典型配置
-
-| 场景 | `--quantization` | `--dtype` | `--kv-cache-dtype` | 结果 |
-|------|------------------|-----------|--------------------|------|
-| 未量化 FP16 基线 | 省略 | `float16` | `float16` | 浮点权重和激活为 FP16，KV Cache 为 FP16。 |
-| 未量化 BF16 基线 | 省略 | `bfloat16` | `bfloat16` | 浮点权重、激活和 KV Cache 为 BF16；KV 容量与 FP16 相同。 |
-| AWQ W4A16，FP16 KV | `awq` | `float16` | `float16` | 量化层权重为 AWQ INT4，普通激活和 KV Cache 为 FP16。权重释放显存，但单 token KV 大小不变。 |
-| AWQ W4A16，FP8 KV | `awq` | `float16` | `fp8` | AWQ 减少权重显存，FP8 直接减少单 token KV 显存，两种收益叠加。 |
-| FP8 权重，BF16 KV | `fp8` | `bfloat16` | `bfloat16` | 量化层使用 FP8 方案，普通浮点张量和 KV Cache 使用 BF16；单 token KV 大小仍为 2 bytes/value。 |
-
-AWQ 与 FP16 KV Cache 的完整命令如下。模型路径需要指向已经完成 AWQ 量化的 checkpoint：
-
-```bash
-vllm serve /path/to/model-awq \
-  --quantization awq \
-  --dtype float16 \
-  --kv-cache-dtype float16
-```
-
-这组参数表示 AWQ INT4 权重、FP16 普通激活和 FP16 KV Cache。`--quantization awq` 不会把 KV Cache 转换成 INT4；如需压缩 KV Cache，需要单独设置 `--kv-cache-dtype fp8`。
-
-### 对比实验的控制变量
-
-比较权重精度时，应固定模型架构、请求长度、并发量和 `--kv-cache-dtype`，分别改变 `--dtype` 或 `--quantization`。比较 KV Cache 精度时，应固定 checkpoint、`--dtype`、`--quantization` 和工作负载，只改变 `--kv-cache-dtype`。否则无法判断显存、性能或生成质量的变化来自权重量化还是 KV Cache 量化。
-
-### 参考文档
-
-| 文档 | 内容 |
+| 参数 | 含义 |
 |------|------|
-| [vLLM `--dtype`](https://docs.vllm.ai/en/latest/configuration/engine_args/#-dtype) | 基础浮点权重和激活 dtype。 |
-| [vLLM `--quantization`](https://docs.vllm.ai/en/latest/configuration/engine_args/#-quantization) | 权重量化方法与 checkpoint 自动识别规则。 |
-| [vLLM `--kv-cache-dtype`](https://docs.vllm.ai/en/latest/configuration/engine_args/#-kv-cache-dtype) | KV Cache 存储 dtype 和支持格式。 |
-| [vLLM Quantized KV Cache](https://docs.vllm.ai/en/latest/features/quantization/quantized_kvcache/) | FP8 KV Cache、scale 和校准方式。 |
-| [LLM Compressor AWQ](https://docs.vllm.ai/projects/llm-compressor/en/latest/examples/awq/) | AWQ 校准、量化和 checkpoint 保存示例。 |
+| `batch_size` | Batch 中的序列数量 |
+| `sequence_length` | 每个序列缓存的 token 数 |
+| `num_layers` | 模型层数 |
+| `2` | Key 和 Value |
+| `num_key_value_heads` | 每层的 KV Head 数；MHA 通常与 Query Head 数相同，GQA 和 MQA 更少 |
+| `head_dim` | 单个 KV Head 的维度 |
+| `precision_bytes` | 每个 K/V 元素占用的字节数；例如 FP16/BF16 为 2 bytes，FP8 为 1 byte |
+
+可以使用 [Modular LLM Inference Handbook 的 KV Cache 计算说明](https://handbook.modular.com/inference-optimization/kv-cache-offloading/)对照标准公式，也可以通过 [KVCache.AI Calculator](https://kvcache.ai/tools/kv-cache-calculator/)选择具体模型、序列数量和 KV 精度进行估算。

--- a/interview/intelligent-routing.mdx
+++ b/interview/intelligent-routing.mdx
@@ -1,0 +1,94 @@
+---
+title: "智能路由"
+description: "Semantic Router 多轮上下文与路由决策面试题"
+---
+
+## 多轮对话上下文
+
+Semantic Router 在多轮对话中是否会传递上下文？
+
+**会。** 使用 Chat Completions API 时，客户端需要在每轮请求的 `messages` 中重新提交历史消息；使用 Responses API 时，Semantic Router 可以根据 `previous_response_id` 读取对话链，并还原成完整的 `messages`。
+
+[启用 Responses API 存储且请求没有设置 `store: false`](https://github.com/vllm-project/semantic-router/blob/790e32d6ad475390c89c95eb4cc1ecc820435d87/src/semantic-router/pkg/extproc/req_filter_response_api.go#L239-L250) 时，Semantic Router 会把每轮 Response 的 input、output 和 `previous_response_id` 保存到 [Response Store](https://github.com/vllm-project/semantic-router/blob/790e32d6ad475390c89c95eb4cc1ecc820435d87/src/semantic-router/pkg/responsestore/interface.go#L11-L34)，存储后端支持[进程内存和 Redis](https://github.com/vllm-project/semantic-router/blob/790e32d6ad475390c89c95eb4cc1ecc820435d87/src/semantic-router/pkg/responsestore/factory.go#L8-L20)。下一轮请求传入 `previous_response_id` 后，Router 先查询对应的 Response，再沿其中保存的上一条 Response ID 逐条向前查找，最终还原完整会话。内存后端会在 Router 重启后丢失记录；Redis 后端可供多个 Router 副本共享，数据是否持久化取决于 Redis 的持久化配置。
+
+需要区分“传递给模型的上下文”和“用于路由分类的上下文”。后端模型会收到请求携带的完整 `messages`；但 Domain、Keyword、Embedding 和 Complexity 等路由信号默认只分析最后一条用户消息，并不会利用全部历史判断当前意图。具体实现可参考 [消息提取](https://github.com/vllm-project/semantic-router/blob/790e32d6ad475390c89c95eb4cc1ecc820435d87/src/semantic-router/pkg/extproc/utils_fast.go#L160-L224)和 [Signal 输入分发](https://github.com/vllm-project/semantic-router/blob/790e32d6ad475390c89c95eb4cc1ecc820435d87/src/semantic-router/pkg/classification/classifier_signal_dispatch.go#L16-L111)。
+
+## 话题切换时的路由决策
+
+在一个多轮对话中，假如一开始讨论经济问题，后来又讨论数学问题，Semantic Router 如何决策？
+
+默认情况下，Router 根据当前用户消息判断意图。当前消息是明确的数学问题时，会匹配 Math Decision 并选择数学模型。请求中携带的经济问题历史仍会传给数学模型，但不同模型不能复用彼此的 KV Cache，因此数学模型需要对完整上下文重新执行 Prefill。
+
+如果启用了 [Protection](https://github.com/vllm-project/semantic-router/blob/790e32d6ad475390c89c95eb4cc1ecc820435d87/website/docs/tutorials/learning/protection.md)，Math Decision 会先提出数学模型，Protection 再决定是否切换。`scope` 决定哪些请求共享“当前模型”状态。
+
+Conversation 是一条可以包含多轮问答的对话线程，不是单轮问答。Session 是更大的业务会话，可以包含多个 Conversation。例如：
+
+```text
+Session S1
+├── Conversation C1：讨论经济问题（多轮问答）
+└── Conversation C2：讨论数学问题（多轮问答）
+```
+
+Session 和 Conversation 的边界由业务方定义，并通过 [`x-session-id` 和 `x-conversation-id`](https://github.com/vllm-project/semantic-router/blob/790e32d6ad475390c89c95eb4cc1ecc820435d87/website/docs/tutorials/learning/protection.md#L29-L58) 传给 Semantic Router。`scope: conversation` 需要两个 ID；`scope: session` 只需要 Session ID。
+
+`scope: conversation` 按 Session ID 和 Conversation ID 保存状态，只在当前 Conversation 内保护原模型；新建 Conversation 后可以重新路由。`scope: session` 只按 Session ID 保存状态，同一 Session 下的多个 Conversation 共用当前模型。
+
+当前模型仍可用、Session 未超时且未触发 Rescue Switch 时，[Session Scope 会直接保留当前模型](https://github.com/vllm-project/semantic-router/blob/790e32d6ad475390c89c95eb4cc1ecc820435d87/src/semantic-router/pkg/extproc/router_learning_protection.go#L454-L494)，所以它比 Conversation Scope 的切换约束更强。若数学任务必须使用数学模型，可以在 Math Decision 中配置 [`adaptations.mode: bypass`](https://github.com/vllm-project/semantic-router/blob/790e32d6ad475390c89c95eb4cc1ecc820435d87/src/semantic-router/pkg/config/learning_config.go#L180-L213)。该配置会跳过这个 Decision 的全部 Router Learning，包括 Adaptation 和 Protection，因此模型选择不会被学习层改写；历史上下文仍会正常传递。
+
+下面的配置假设 `economy-model` 和 `math-model` 已经注册。Protection 在整个 Session 内保持当前模型，但 Math Decision 会绕过全部 Router Learning：
+
+```yaml
+global:
+  router:
+    learning:
+      enabled: true                  # 启用跨请求的 Router Learning
+      protection:
+        enabled: true                # 启用模型连续性保护
+        scope: session               # 按 Session ID 共享当前模型状态
+        identity:
+          headers:
+            session: x-session-id    # 客户端需要传递这个请求头
+            conversation: x-conversation-id  # Session Scope 下不参与状态键
+
+routing:
+  strategy: priority                 # 多个 Decision 命中时，优先级高者胜出
+  signals:
+    keywords:
+      - name: economy_keywords
+        operator: OR                 # 任意一个关键词匹配即可
+        method: ngram                # 使用字符 N-gram 近似匹配
+        keywords: ["经济", "通胀", "GDP", "economy", "inflation"]
+        case_sensitive: false
+        ngram_threshold: 0.4         # 相似度阈值
+      - name: math_keywords
+        operator: OR
+        method: ngram
+        keywords: ["方程", "积分", "矩阵", "equation", "calculus"]
+        case_sensitive: false
+        ngram_threshold: 0.4
+
+  decisions:
+    - name: math
+      priority: 200                  # 高于 Economy Decision
+      rules:
+        operator: AND                # 所有条件都要满足，此处只有一个
+        conditions:
+          - type: keyword            # 引用上面的 Keyword Signal
+            name: math_keywords
+      modelRefs:
+        - model: math-model          # Math Decision 的模型
+      adaptations:
+        mode: bypass                 # 跳过该 Decision 的全部 Router Learning
+
+    - name: economy
+      priority: 100
+      rules:
+        operator: AND
+        conditions:
+          - type: keyword
+            name: economy_keywords
+      modelRefs:
+        - model: economy-model
+```
+
+同一 Session 的前几轮讨论经济问题时，Economy Decision 选择 `economy-model`。后续消息“求解方程 2x + 3 = 9”命中优先级更高的 Math Decision，并选择 `math-model`；`bypass` 使 Adaptation 和 Protection 都不再改写该结果，最终请求直接发给 `math-model`。如果只想跳过 Protection、仍保留 Adaptation，可以改用 `adaptations.protection.mode: bypass`。

--- a/resources/index.mdx
+++ b/resources/index.mdx
@@ -27,7 +27,8 @@ export const ResourceCard = ({ filename, title, description, href }) => {
 
 <div className="grid sm:grid-cols-2 gap-x-6 gap-y-4">
   <ResourceCard filename="rocket" title="LLM 基础" description="Transformer、GPT 实现与入门课程" href="/resources/llm-foundations" />
-  <ResourceCard filename="editor" title="训练" description="预训练、Scaling、分布式训练与 RL" href="/resources/training" />
+  <ResourceCard filename="editor" title="训练" description="预训练、Scaling 与分布式训练" href="/resources/training" />
+  <ResourceCard filename="rocket" title="RL" description="RLHF、Agentic RL、Rollout 与训练基础设施" href="/resources/rl" />
   <ResourceCard filename="cli" title="推理" description="Serving、缓存、调度、PD 分离与量化" href="/resources/inference" />
   <ResourceCard filename="components" title="RAG" description="检索、Reranking、Context 管理、Serving 与评测" href="/resources/rag" />
   <ResourceCard filename="components" title="GPU 编程" description="CUDA、Triton、CUTLASS 与 Kernel 优化" href="/resources/gpu-programming" />

--- a/resources/rl.mdx
+++ b/resources/rl.mdx
@@ -1,0 +1,10 @@
+---
+title: "RL"
+description: "RLHF、Agentic RL 与强化学习训练系统资源"
+---
+
+## RL 系统与基础设施
+
+| 资源 | 类型 | 简介 |
+|------|------|------|
+| [Awesome-ML-SYS-Tutorial（中文版）](https://github.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/blob/main/README-cn.md) | 学习笔记合集 | 以 RL Infra 为主线的中文 ML Systems 学习笔记，涵盖 slime、AReaL、verl、OpenRLHF、Agentic RL、训推一致性、权重更新、FSDP/Megatron 训练后端，并延伸到 SGLang 推理系统与 AI Infra 基础 |

--- a/resources/training.mdx
+++ b/resources/training.mdx
@@ -1,6 +1,6 @@
 ---
 title: "训练"
-description: "LLM 预训练、Scaling、强化学习与训练基础设施"
+description: "LLM 预训练、Scaling、分布式训练与训练基础设施"
 ---
 
 ## 模型架构与 Scaling
@@ -10,7 +10,7 @@ description: "LLM 预训练、Scaling、强化学习与训练基础设施"
 | [How to Scale Your Model](https://jax-ml.github.io/scaling-book/) | 在线书籍 | 从系统视角讲解 LLM 在 TPU 和 GPU 上的训练与推理扩展，涵盖 Roofline 分析、硬件互连、Transformer 计算与内存、并行策略，以及基于 JAX 的性能分析与编程实践。 | [GitHub](https://github.com/jax-ml/scaling-book) |
 | [Awesome-LM-Architecture](https://github.com/Superposition09m/Awesome-LM-Architecture) | 资源合集 | 按核心组件、模型架构、扩展与预训练、模型技术报告整理语言模型架构，涵盖位置编码、归一化、Attention、线性模型、Test-Time Learning、MoE 和 Scaling Laws。 | |
 
-## 预训练、RL 与基础设施
+## 预训练与基础设施
 
 | 资源 | 类型 | 简介 |
 |------|------|------|


### PR DESCRIPTION
## Summary

Add topic-based interview documentation for LLM inference and intelligent routing, and split reinforcement-learning material into a dedicated resource category.

## Key Changes

- Refine the KV Cache precision interview answer with clear boundaries between `--dtype`, `--quantization`, and `--kv-cache-dtype`
- Add the KV Cache memory formula and explain AWQ W4A16 weights, activations, scales, and zero points
- Add an **智能路由** interview category covering Semantic Router multi-turn context and topic-switch routing
- Explain Responses API conversation recovery through `previous_response_id` and Response Store
- Explain Conversation and Session protection scopes, Prefix Cache behavior across models, and Decision-level `bypass`
- Include a source-aligned, annotated Semantic Router configuration example
- Add a dedicated **RL** resource category and the Chinese Awesome ML Systems Tutorial

## Impact

Readers can distinguish model precision from KV Cache precision, understand how Semantic Router handles multi-turn conversations, and find reinforcement-learning infrastructure resources from the main navigation.

## Validation

- `jq empty docs.json`
- `git diff --check`
- `mint validate`
- `mint broken-links`
- Verified `/interview/inference` and `/interview/intelligent-routing` in the local Mintlify preview
- Reviewed Semantic Router behavior against upstream commit `790e32d6ad475390c89c95eb4cc1ecc820435d87`
