### PR TITLE
doc: add DeepSeek Harness to open source projects

### DIFF
--- a/projects/agents.mdx
+++ b/projects/agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent"
-description: "Agent 框架、Sandbox、运行时与开发工具"
+description: "Agent 框架、Harness、Sandbox、运行时与开发工具"
 ---
 
 ## Agent 框架
@@ -8,6 +8,12 @@ description: "Agent 框架、Sandbox、运行时与开发工具"
 | 项目 | 简介 | 参考资料 |
 |------|------|----------|
 | [vercel/eve](https://github.com/vercel/eve) | Vercel 开源的文件系统优先持久化 Agent 框架，通过约定目录组织 Instructions、Tools、Skills、Channels 和 Schedules，方便检查、扩展和运行 Agent 项目。 | [官方文档](https://eve.dev/) |
+
+## Agent Harness
+
+| 项目 | 简介 | 参考资料 |
+|------|------|----------|
+| [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) | DeepSeek 开源的插件化 Agent Harness，以 Cordis 为底座，将模型接入、工具执行、会话持久化、上下文管理和交互能力组织为可组合插件。 | [架构参考](https://deepseek-harness.github.io/deepseek-harness/reference/) |
 
 ## Agent Sandbox
 


### PR DESCRIPTION
## Summary

- add a dedicated **Agent Harness** subsection to the open source Agent catalog
- add DeepSeek Harness with a concise description of its plugin-based architecture
- link to the official architecture reference

## Why

DeepSeek Harness is an Agent harness rather than a general Agent framework or sandbox runtime. A separate subsection keeps that responsibility clear and leaves room for future harness projects.

## User impact

Readers can discover DeepSeek Harness from the Agent project catalog and follow its official architecture documentation directly.

## Test plan

- `git diff --check`
- `mint validate`
- `mint broken-links`
- verified the repository and architecture reference return HTTP 200