### PR TITLE
doc: add GPU computing and Agentic RL resources

### DIFF
--- a/resources/gpu-programming.mdx
+++ b/resources/gpu-programming.mdx
@@ -3,12 +3,6 @@ title: "GPU 编程"
 description: "GPU 架构、CUDA、Triton、CUTLASS、TileLang 与 FlashAttention"
 ---
 
-## 综合资源
-
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [NVIDIA Accelerated Computing Hub](https://github.com/NVIDIA/accelerated-computing-hub) | 资源合集 | NVIDIA 维护的 GPU 计算开放学习资料库，汇集用户指南、教程、示例、最佳实践和优化方法，覆盖 CUDA C++、加速 Python、标准并行、Warp、nvmath-python 与 GPU 部署，并提供可在 Brev 或 Colab 运行的交互式内容。 |
-
 ## GPU 架构
 
 | 资源 | 类型 | 简介 |
@@ -20,6 +14,7 @@ description: "GPU 架构、CUDA、Triton、CUTLASS、TileLang 与 FlashAttention
 
 | 资源 | 类型 | 简介 |
 |------|------|------|
+| [NVIDIA Accelerated Computing Hub](https://github.com/NVIDIA/accelerated-computing-hub) | 资源合集 | NVIDIA 维护的 GPU 计算开放学习资料库，汇集用户指南、教程、示例、最佳实践和优化方法，覆盖 CUDA C++、加速 Python、标准并行、Warp、nvmath-python 与 GPU 部署，并提供可在 Brev 或 Colab 运行的交互式内容。 |
 | [CUDA 教程合集 - 比飞鸟贵重的多_HKL](https://space.bilibili.com/218427631/lists/4695308?type=series) | 视频合集 | 中文 CUDA 系列课程，从并行编程和 Kernel 基础逐步进入内存层次、常用算子实现与性能优化。 |
 | [CUDA Programming Course - High-Performance Computing with GPUs](https://www.youtube.com/watch?v=86FAWCzIe_4) | 视频课程 | 系统介绍 CUDA 编程模型、线程层次、GPU 内存、Kernel 编写和高性能计算中的常见优化方法。 |
 | [How to Optimize a CUDA Matmul Kernel for cuBLAS-like Performance: a Worklog](https://siboehm.com/articles/22/CUDA-MMM) | 博客 | 从朴素 SGEMM 开始，逐步加入合并访存、共享内存、Block Tiling、向量化、自动调优和 Warp Tiling，逼近 cuBLAS 性能。 |

--- a/resources/gpu-programming.mdx
+++ b/resources/gpu-programming.mdx
@@ -3,6 +3,12 @@ title: "GPU 编程"
 description: "GPU 架构、CUDA、Triton、CUTLASS、TileLang 与 FlashAttention"
 ---
 
+## 综合资源
+
+| 资源 | 类型 | 简介 |
+|------|------|------|
+| [NVIDIA Accelerated Computing Hub](https://github.com/NVIDIA/accelerated-computing-hub) | 资源合集 | NVIDIA 维护的 GPU 计算开放学习资料库，汇集用户指南、教程、示例、最佳实践和优化方法，覆盖 CUDA C++、加速 Python、标准并行、Warp、nvmath-python 与 GPU 部署，并提供可在 Brev 或 Colab 运行的交互式内容。 |
+
 ## GPU 架构
 
 | 资源 | 类型 | 简介 |

--- a/resources/rl.mdx
+++ b/resources/rl.mdx
@@ -8,3 +8,4 @@ description: "RLHF、Agentic RL 与强化学习训练系统资源"
 | 资源 | 类型 | 简介 |
 |------|------|------|
 | [Awesome-ML-SYS-Tutorial（中文版）](https://github.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/blob/main/README-cn.md) | 学习笔记合集 | 以 RL Infra 为主线的中文 ML Systems 学习笔记，涵盖 slime、AReaL、verl、OpenRLHF、Agentic RL、训推一致性、权重更新、FSDP/Megatron 训练后端，并延伸到 SGLang 推理系统与 AI Infra 基础 |
+| [Accio-Lab/Dressage](https://github.com/Accio-Lab/Dressage) | 开源框架 | 基于 slime 的 Agentic RL 训练框架，打通策略 Rollout、Sandbox 工具执行、Token 级轨迹记录和训练样本转换，统一支持 Python 白盒工具循环与 Codex、Claude Code 等 HTTP 黑盒 Agent。 |


### PR DESCRIPTION
## Summary

- add NVIDIA Accelerated Computing Hub to the **CUDA** learning resources
- describe it as a curated collection covering CUDA C++, accelerated Python, standard parallelism, Warp, nvmath-python, and GPU deployment
- add Dressage to **RL Systems and Infrastructure**
- describe Dressage's role in connecting agent rollouts, sandbox execution, token-level trajectories, and RL training

## Why

Both additions provide broad entry points into important AI infrastructure areas: GPU programming education and scalable Agentic RL. Keeping them in their closest existing topic sections makes the resource taxonomy easy to browse.

## User impact

Readers can find NVIDIA's GPU computing tutorials and the Dressage Agentic RL framework directly from the CUDA and RL resource sections.

## Test plan

- `git diff --check`
- `mint validate`
- `mint broken-links`
- verified both external links return HTTP 200
