### PR TITLE
doc: expand and standardize learning resources

### DIFF
--- a/resources/agents.mdx
+++ b/resources/agents.mdx
@@ -5,36 +5,36 @@ description: "Agent 基础、Coding Agent、Memory、Harness Engineering 与自�
 
 ## Agent 基础与 Coding Agent
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [Learn Claude Code](https://github.com/shareAI-lab/learn-claude-code) | 实践课程 | 从零构建类 Claude Code 的 AI Agent，12 个渐进式课程涵盖 Agent Loop、工具调用、子代理、上下文压缩、任务系统、多代理协作和 Worktree 隔离。 |
-| [从零开始理解 Agent](https://mp.weixin.qq.com/s/Ur3jsyDYobBocXd8ts0gpw) | 教程 | 从极简实现出发，逐层拆解 OpenClaw、Claude Code 等 AI Agent 的循环、工具、记忆和 Skill 等核心概念。 |
-| [nanoAgent](https://github.com/GitHubxsy/nanoAgent) | 实践项目 | 通过小型代码和配套章节讲解大模型、Agent 与 Skill 的底层原理，并展示从最小 Agent Loop 到工程化能力的演进。 |
-| [Self-Evolving Coding Agents 最新综述](https://mp.weixin.qq.com/s/hSrJLcZN3j7J7X02N2HIMg) | 综述 | 系统梳理 Coding Agent 如何利用测试、编译和执行轨迹持续更新框架、记忆、技能与工具、模型以及协作工作流，并讨论进化时机、反馈证据、评估与安全挑战。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [Learn Claude Code](https://github.com/shareAI-lab/learn-claude-code) | 实践课程 | 从零构建类 Claude Code 的 AI Agent，12 个渐进式课程涵盖 Agent Loop、工具调用、子代理、上下文压缩、任务系统、多代理协作和 Worktree 隔离。 | |
+| [从零开始理解 Agent](https://mp.weixin.qq.com/s/Ur3jsyDYobBocXd8ts0gpw) | 教程 | 从极简实现出发，逐层拆解 OpenClaw、Claude Code 等 AI Agent 的循环、工具、记忆和 Skill 等核心概念。 | |
+| [nanoAgent](https://github.com/GitHubxsy/nanoAgent) | 实践项目 | 通过小型代码和配套章节讲解大模型、Agent 与 Skill 的底层原理，并展示从最小 Agent Loop 到工程化能力的演进。 | |
+| [Self-Evolving Coding Agents 最新综述](https://mp.weixin.qq.com/s/hSrJLcZN3j7J7X02N2HIMg) | 综述 | 系统梳理 Coding Agent 如何利用测试、编译和执行轨迹持续更新框架、记忆、技能与工具、模型以及协作工作流，并讨论进化时机、反馈证据、评估与安全挑战。 | |
 
 ## Agent Memory
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [A Survey of Agent Memory in the Second Half: Towards Self-Evolving and Long-Horizon Agents](https://arxiv.org/abs/2602.06052) | 综述论文 | 从记忆载体、认知机制和记忆主体三个维度整理 Agent Memory，并讨论单 Agent 与多 Agent 系统中的记忆操作、可学习的管理策略、评测与开放问题。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [A Survey of Agent Memory in the Second Half: Towards Self-Evolving and Long-Horizon Agents](https://arxiv.org/abs/2602.06052) | 综述论文 | 从记忆载体、认知机制和记忆主体三个维度整理 Agent Memory，并讨论单 Agent 与多 Agent 系统中的记忆操作、可学习的管理策略、评测与开放问题。 | |
 
 ## Harness Engineering
 
 Harness Engineering 指的是一种开发方式：工程师设计环境、规则和测试反馈系统，让 AI Agent 自动生成并改进代码。
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents) | 官方博客 | Anthropic 总结跨多个上下文窗口运行 Coding Agent 的方法，包括初始化 Agent、进度文件、功能清单、增量提交和端到端测试。 |
-| [Harness Engineering: Leveraging Codex in an Agent-First World](https://openai.com/index/harness-engineering/) | 官方博客 | OpenAI 总结 Agent-first 软件工程实践，重点介绍仓库知识、可读环境、架构约束、自动化反馈和 Agent-to-Agent Review。 |
-| [Minions: Stripe’s One-Shot, End-to-End Coding Agents](https://stripe.dev/blog/minions-stripes-one-shot-end-to-end-coding-agents) | 官方博客 | 介绍 Stripe 内部 Coding Agent Minions 如何从任务描述出发完成实现、验证并提交 Pull Request，以及支撑它的工程环境。 |
-| [Minions: Stripe’s One-Shot, End-to-End Coding Agents - Part 2](https://stripe.dev/blog/minions-stripes-one-shot-end-to-end-coding-agents-part-2) | 官方博客 | 继续讨论 Minions 在大规模使用中的可靠性、人工审查、评测与迭代机制，以及每周合并大量 Agent PR 的实践经验。 |
-| [Vibe Coding AReaL：零手打代码开发分布式 RL 训练框架](https://zhuanlan.zhihu.com/p/2003269671630165191) | 博客 | 记录使用 Coding Agent 开发分布式强化学习训练框架 AReaL 的过程，关注任务拆解、反馈循环和无手写代码协作方式。 |
-| [Are Agent Harnesses Bringing Back Vibe Coding?](https://www.youtube.com/watch?v=13HP_bSeNjU) | 视频 | 讨论 Agent Harness 如何通过工具、上下文、约束和验证机制提升 Coding Agent 的自治能力，并重新界定 Vibe Coding。 |
-| [HarnessEval: The Era of Harness for Benchmarking](https://mirros.ai/blog/harnesseval)（[代码](https://github.com/mirros-lab/harnesseval-w)） | 研究博客 / 开源项目 | 将 Harness 用于交互式世界模型评测：Agent 根据案例选择 Skill、拆解问题并调用子 Agent，最终输出可核查的 Evidence Tree，而不只提供汇总分数。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents) | 官方博客 | Anthropic 总结跨多个上下文窗口运行 Coding Agent 的方法，包括初始化 Agent、进度文件、功能清单、增量提交和端到端测试。 | |
+| [Harness Engineering: Leveraging Codex in an Agent-First World](https://openai.com/index/harness-engineering/) | 官方博客 | OpenAI 总结 Agent-first 软件工程实践，重点介绍仓库知识、可读环境、架构约束、自动化反馈和 Agent-to-Agent Review。 | |
+| [Minions: Stripe’s One-Shot, End-to-End Coding Agents](https://stripe.dev/blog/minions-stripes-one-shot-end-to-end-coding-agents) | 官方博客 | 介绍 Stripe 内部 Coding Agent Minions 如何从任务描述出发完成实现、验证并提交 Pull Request，以及支撑它的工程环境。 | |
+| [Minions: Stripe’s One-Shot, End-to-End Coding Agents - Part 2](https://stripe.dev/blog/minions-stripes-one-shot-end-to-end-coding-agents-part-2) | 官方博客 | 继续讨论 Minions 在大规模使用中的可靠性、人工审查、评测与迭代机制，以及每周合并大量 Agent PR 的实践经验。 | |
+| [Vibe Coding AReaL：零手打代码开发分布式 RL 训练框架](https://zhuanlan.zhihu.com/p/2003269671630165191) | 博客 | 记录使用 Coding Agent 开发分布式强化学习训练框架 AReaL 的过程，关注任务拆解、反馈循环和无手写代码协作方式。 | |
+| [Are Agent Harnesses Bringing Back Vibe Coding?](https://www.youtube.com/watch?v=13HP_bSeNjU) | 视频 | 讨论 Agent Harness 如何通过工具、上下文、约束和验证机制提升 Coding Agent 的自治能力，并重新界定 Vibe Coding。 | |
+| [HarnessEval: The Era of Harness for Benchmarking](https://mirros.ai/blog/harnesseval) | 研究博客 / 开源项目 | 将 Harness 用于交互式世界模型评测：Agent 根据案例选择 Skill、拆解问题并调用子 Agent，最终输出可核查的 Evidence Tree，而不只提供汇总分数。 | [代码](https://github.com/mirros-lab/harnesseval-w) |
 
 ## 自动化 AI 研究
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [autoresearch](https://github.com/karpathy/autoresearch) | 实践项目 | 让 AI Agent 在单 GPU 上自动修改 nanochat 训练代码，以固定 5 分钟预算运行实验、评估结果并保留有效改动，形成最小化的自动研究闭环。 |
-| [First Steps Toward Automated AI Research](https://www.recursive.com/articles/first-steps-toward-automated-ai-research) | 研究博客 | Recursive 对自动研究系统的早期实践总结，涵盖长周期并行探索、结果验证，以及在 NanoChat、NanoGPT Speedrun 和 GPU Kernel 优化任务上的实验。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [autoresearch](https://github.com/karpathy/autoresearch) | 实践项目 | 让 AI Agent 在单 GPU 上自动修改 nanochat 训练代码，以固定 5 分钟预算运行实验、评估结果并保留有效改动，形成最小化的自动研究闭环。 | |
+| [First Steps Toward Automated AI Research](https://www.recursive.com/articles/first-steps-toward-automated-ai-research) | 研究博客 | Recursive 对自动研究系统的早期实践总结，涵盖长周期并行探索、结果验证，以及在 NanoChat、NanoGPT Speedrun 和 GPU Kernel 优化任务上的实验。 | |

--- a/resources/books.mdx
+++ b/resources/books.mdx
@@ -3,9 +3,9 @@ title: "书籍"
 description: "AI Infra 领域的推荐书籍"
 ---
 
-| 书名 | 简介 | 资料 |
-|------|------|------|
-| [How to Scale Your Model](https://jax-ml.github.io/scaling-book/) | 从系统视角讲解 LLM 在 TPU 和 GPU 上的训练与推理扩展，涵盖 Roofline 分析、硬件互连、Transformer 计算与内存、并行策略，以及基于 JAX 的性能分析与编程实践。 | [GitHub](https://github.com/jax-ml/scaling-book) |
-| [AI Systems Performance Engineering](https://www.oreilly.com/library/view/ai-systems-performance/9798341627772/) | 逐步讲解 GPU CUDA Kernel 调优、基于 PyTorch 的算法优化以及多节点训练与推理系统的优化方法。同时涵盖 GPU 集群扩展、分布式模型训练和推理服务的性能调优。书末附 175+ 项经过验证的实战优化清单。 | [GitHub](https://github.com/cfregly/ai-performance-engineering) |
-| [Build a Large Language Model (From Scratch)](https://www.manning.com/books/build-a-large-language-model-from-scratch) | 从零规划并编写 LLM 的各个组件，涵盖数据集准备、文本分类微调、基于人类反馈的指令对齐，以及加载预训练权重等完整流程。 | [GitHub](https://github.com/rasbt/LLMs-from-scratch) |
-| [nanoGPT](https://github.com/karpathy/nanoGPT) | 精简的 PyTorch GPT 训练与微调实现，可从字符级 toy GPT 入门，并进一步复现 GPT-2 124M。项目已停止维护，作者推荐使用后续项目 [nanochat](https://github.com/karpathy/nanochat)。 | [配套视频](https://www.youtube.com/watch?v=kCc8FmEb1nY) |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [How to Scale Your Model](https://jax-ml.github.io/scaling-book/) | 在线书籍 | 从系统视角讲解 LLM 在 TPU 和 GPU 上的训练与推理扩展，涵盖 Roofline 分析、硬件互连、Transformer 计算与内存、并行策略，以及基于 JAX 的性能分析与编程实践。 | [GitHub](https://github.com/jax-ml/scaling-book) |
+| [AI Systems Performance Engineering](https://www.oreilly.com/library/view/ai-systems-performance/9798341627772/) | 书籍 | 逐步讲解 GPU CUDA Kernel 调优、基于 PyTorch 的算法优化以及多节点训练与推理系统的优化方法。同时涵盖 GPU 集群扩展、分布式模型训练和推理服务的性能调优。书末附 175+ 项经过验证的实战优化清单。 | [GitHub](https://github.com/cfregly/ai-performance-engineering) |
+| [Build a Large Language Model (From Scratch)](https://www.manning.com/books/build-a-large-language-model-from-scratch) | 书籍 | 从零规划并编写 LLM 的各个组件，涵盖数据集准备、文本分类微调、基于人类反馈的指令对齐，以及加载预训练权重等完整流程。 | [GitHub](https://github.com/rasbt/LLMs-from-scratch) |
+| [nanoGPT](https://github.com/karpathy/nanoGPT) | 实践项目 | 精简的 PyTorch GPT 训练与微调实现，可从字符级 toy GPT 入门，并进一步复现 GPT-2 124M。项目已停止维护，作者推荐使用后续项目 nanochat。 | [nanochat](https://github.com/karpathy/nanochat) · [配套视频](https://www.youtube.com/watch?v=kCc8FmEb1nY) |

--- a/resources/collections.mdx
+++ b/resources/collections.mdx
@@ -3,8 +3,8 @@ title: "合集"
 description: "AI Infra 领域的资源合集与 Awesome Lists"
 ---
 
-| 合集 | 简介 |
-|------|------|
-| [ai-inference-resources](https://github.com/aerlabsAI/ai-inference-resources) | 面向 AI 推理系统工程师的精选资源合集，涵盖 LLM Serving、GPU Kernel 编程、Attention 机制、量化、分布式推理和生产部署。|
-| [LeetCUDA](https://github.com/xlite-dev/LeetCUDA) | 面向初学者的现代 CUDA 学习笔记，包含 PyTorch、200 多个 CUDA 内核、Tensor Core、HGEMM 和 FA-2 MMA。|
-| [Awesome-LM-Architecture](https://github.com/Superposition09m/Awesome-LM-Architecture) | 按“核心组件、模型架构、扩展与预训练、模型技术报告”自底向上整理语言模型架构，涵盖位置编码、归一化、Attention、线性模型、Test-Time Learning、MoE 和 Scaling Laws 等主题。|
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [ai-inference-resources](https://github.com/aerlabsAI/ai-inference-resources) | 资源合集 | 面向 AI 推理系统工程师的精选资源合集，涵盖 LLM Serving、GPU Kernel 编程、Attention 机制、量化、分布式推理和生产部署。 | |
+| [LeetCUDA](https://github.com/xlite-dev/LeetCUDA) | 资源合集 | 面向初学者的现代 CUDA 学习笔记，包含 PyTorch、200 多个 CUDA 内核、Tensor Core、HGEMM 和 FA-2 MMA。 | |
+| [Awesome-LM-Architecture](https://github.com/Superposition09m/Awesome-LM-Architecture) | 资源合集 | 按“核心组件、模型架构、扩展与预训练、模型技术报告”自底向上整理语言模型架构，涵盖位置编码、归一化、Attention、线性模型、Test-Time Learning、MoE 和 Scaling Laws 等主题。 | |

--- a/resources/courses.mdx
+++ b/resources/courses.mdx
@@ -5,28 +5,28 @@ description: "AI Infra 领域的系统性课程"
 
 ## LLM
 
-| 课程 | 简介 |
-|------|------|
-| [CSCI 1390, Spring 2025: Systems for Machine Learning](https://cs.brown.edu/courses/csci1390/) | 主题包括高效训练和推理、理解如何构建硬件 ML 算法、理解 ML 算法性能、GPU 编程和 CUDA、Transformer 架构、高效检索等 |
-| [CS336: Language Modeling from Scratch (Stanford / Spring 2025)](https://cs336.stanford.edu/spring2025/index.html) <br/> [配套视频](https://www.bilibili.com/video/BV1zvt9zKEK6) | 手把手从零构建一个完整的语言模型——从 tokenizer、Transformer 到分布式训练、数据处理和 RLHF 对齐，5 个实战 assignment 覆盖 LLM 全链路，代码全部开源 |
-| [The Smol Training Playbook](https://huggingface.co/spaces/HuggingFaceTB/smol-training-playbook) | 以 SmolLM3 的真实训练过程为主线，覆盖模型目标与规模选择、架构和数据配比、消融实验、分布式预训练、监控排障、评测及后训练。内容串联了完整训练流程，适合作为 LLM 预训练入门指南。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [CSCI 1390, Spring 2025: Systems for Machine Learning](https://cs.brown.edu/courses/csci1390/) | 课程 | 主题包括高效训练和推理、理解如何构建硬件 ML 算法、理解 ML 算法性能、GPU 编程和 CUDA、Transformer 架构、高效检索等 | |
+| [CS336: Language Modeling from Scratch (Stanford / Spring 2025)](https://cs336.stanford.edu/spring2025/index.html) | 课程 | 手把手从零构建一个完整的语言模型——从 tokenizer、Transformer 到分布式训练、数据处理和 RLHF 对齐，5 个实战 assignment 覆盖 LLM 全链路，代码全部开源 | [配套视频](https://www.bilibili.com/video/BV1zvt9zKEK6) |
+| [The Smol Training Playbook](https://huggingface.co/spaces/HuggingFaceTB/smol-training-playbook) | 教程 | 以 SmolLM3 的真实训练过程为主线，覆盖模型目标与规模选择、架构和数据配比、消融实验、分布式预训练、监控排障、评测及后训练。内容串联了完整训练流程，适合作为 LLM 预训练入门指南。 | |
 
 ## 性能分析
 
-| 资料 | 简介 |
-|------|------|
-| [Stanford CS336 Assignment 2: Systems](https://github.com/stanford-cs336/assignment2-systems/tree/main) | 围绕 Transformer 训练系统实践性能基准测试、分析与优化，并实现分布式训练。整体计算资源要求不高，强烈推荐完整完成。 |
-| [PyTorch Profiling with NVIDIA Nsight](https://docs.lxp.lu/howto/pytorch-profiling-with-nsight/) | 详细讲解 Nsight Systems 和 Nsight Compute 的分工、报告采集、CLI 与 UI 分析、NVTX 标记、时间线解读，以及 PyTorch 常见性能瓶颈的诊断与优化。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [Stanford CS336 Assignment 2: Systems](https://github.com/stanford-cs336/assignment2-systems/tree/main) | 实践课程 | 围绕 Transformer 训练系统实践性能基准测试、分析与优化，并实现分布式训练。整体计算资源要求不高，强烈推荐完整完成。 | |
+| [PyTorch Profiling with NVIDIA Nsight](https://docs.lxp.lu/howto/pytorch-profiling-with-nsight/) | 教程 | 详细讲解 Nsight Systems 和 Nsight Compute 的分工、报告采集、CLI 与 UI 分析、NVTX 标记、时间线解读，以及 PyTorch 常见性能瓶颈的诊断与优化。 | |
 
 ## GPU Kernel 编程
 
-| 资料 | 简介 |
-|------|------|
-| [TileLang Puzzles](https://github.com/tile-ai/tilelang-puzzles) | 通过 10 个渐进式练习入门 TileLang，从基础操作逐步推进到 GEMM 和 FlashAttention。每道练习均可独立运行，并提供参考实现用于对照。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [TileLang Puzzles](https://github.com/tile-ai/tilelang-puzzles) | 实践项目 | 通过 10 个渐进式练习入门 TileLang，从基础操作逐步推进到 GEMM 和 FlashAttention。每道练习均可独立运行，并提供参考实现用于对照。 | |
 
 ## Agent
 
-| 课程 | 简介 |
-|------|------|
-| [Learn Claude Code](https://github.com/shareAI-lab/learn-claude-code) | 从零到一构建一个类 Claude Code 的 AI Agent，12 个渐进式课程，涵盖 Agent Loop、工具调用、子代理、上下文压缩、任务系统、多代理协作、Worktree 隔离等机制 |
-| [从零开始理解 Agent](https://mp.weixin.qq.com/s/Ur3jsyDYobBocXd8ts0gpw) | 从一个极简开源项目 [nanoAgent](https://github.com/GitHubxsy/nanoAgent) 出发，逐层拆解 OpenClaw / Claude Code 等 AI Agent 背后的全部核心概念 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [Learn Claude Code](https://github.com/shareAI-lab/learn-claude-code) | 实践课程 | 从零到一构建一个类 Claude Code 的 AI Agent，12 个渐进式课程，涵盖 Agent Loop、工具调用、子代理、上下文压缩、任务系统、多代理协作、Worktree 隔离等机制 | |
+| [从零开始理解 Agent](https://mp.weixin.qq.com/s/Ur3jsyDYobBocXd8ts0gpw) | 教程 | 从一个极简开源项目 nanoAgent 出发，逐层拆解 OpenClaw / Claude Code 等 AI Agent 背后的全部核心概念 | [nanoAgent](https://github.com/GitHubxsy/nanoAgent) |

--- a/resources/gpu-programming.mdx
+++ b/resources/gpu-programming.mdx
@@ -45,8 +45,7 @@ description: "GPU 架构、CUDA、Triton、CUTLASS、TileLang 与 FlashAttention
 
 | 资源 | 类型 | 简介 |
 |------|------|------|
-| [FlashAttention为什么又快又节省GPU显存？](https://www.bilibili.com/video/BV1TU8x6hEVb) | 视频 | 从 GPU 的 SRAM/HBM 存储层级和数据搬运成本出发，推导 Kernel Fusion、Online Softmax 与 Tiling 如何让 FlashAttention 在保持精确 Attention 计算的同时减少 HBM 读写和显存占用。 |
-| [FlashAttention：为什么加速推理的同时还能节省显存](https://zhangchitc.github.io/codex/078_flash_attention/visual.html) | 交互式可视化 | 通过八个交互式分屏展示 Attention 的矩阵计算、Kernel Fusion、Online Softmax 递推和 QKV Tiling，直观解释 FlashAttention 如何减少 HBM 数据搬运与中间结果存储。 |
+| [FlashAttention 为什么又快又节省 GPU 显存？](https://www.bilibili.com/video/BV1TU8x6hEVb)（[配套资料](https://zhangchitc.github.io/codex/078_flash_attention/visual.html)） | 视频 | 从 GPU 的 SRAM/HBM 存储层级和数据搬运成本出发，推导 Kernel Fusion、Online Softmax 与 Tiling 如何让 FlashAttention 在保持精确 Attention 计算的同时减少 HBM 读写和显存占用。 |
 | [FlashAttention from First Principles](https://ai.gopubby.com/flashattention-from-first-principles-part-1-5a9f2407d739#bypass) | 博客 | 从标准 Attention 的内存瓶颈出发，推导分块、Online Softmax 和避免物化完整注意力矩阵的实现思路。 |
 | [FlashAttention - Visually and Exhaustively Explained](https://ai.gopubby.com/flashattention-visually-and-exhaustively-explained-d6124670f7fb#bypass) | 博客 | 使用可视化示例解释 FlashAttention 的 Tiling、重计算、Online Softmax、前向与反向过程。 |
 | [Flash Attention 2.0 with Tri Dao](https://www.youtube.com/watch?v=IoMSGuiwV3g&t=2240s) | 视频 | Tri Dao 讲解 FlashAttention-2 的算法设计、并行划分、GPU 利用率和相对第一版的优化。 |

--- a/resources/gpu-programming.mdx
+++ b/resources/gpu-programming.mdx
@@ -5,51 +5,51 @@ description: "GPU 架构、CUDA、Triton、CUTLASS、TileLang 与 FlashAttention
 
 ## GPU 架构
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [Building a Tiny GPU to Understand AI Hardware Engineering](https://levelup.gitconnected.com/building-a-tiny-gpu-to-understand-ai-hardware-engineering-62bb08f2d1d1) | 博客 | 通过构建一个微型 GPU 模型理解线程执行、SIMT、Warp 调度、内存访问和矩阵计算等 AI 加速器基础机制。 |
-| [A History of NVIDIA Stream Multiprocessor](https://fabiensanglard.net/cuda/index.html) | 博客 | 按 Tesla、Fermi、Kepler、Maxwell、Pascal 和 Turing 的演进梳理 NVIDIA SM、CUDA Core、Warp 与专用计算单元的变化。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [Building a Tiny GPU to Understand AI Hardware Engineering](https://levelup.gitconnected.com/building-a-tiny-gpu-to-understand-ai-hardware-engineering-62bb08f2d1d1) | 博客 | 通过构建一个微型 GPU 模型理解线程执行、SIMT、Warp 调度、内存访问和矩阵计算等 AI 加速器基础机制。 | |
+| [A History of NVIDIA Stream Multiprocessor](https://fabiensanglard.net/cuda/index.html) | 博客 | 按 Tesla、Fermi、Kepler、Maxwell、Pascal 和 Turing 的演进梳理 NVIDIA SM、CUDA Core、Warp 与专用计算单元的变化。 | |
 
 ## CUDA
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [NVIDIA Accelerated Computing Hub](https://github.com/NVIDIA/accelerated-computing-hub) | 资源合集 | NVIDIA 维护的 GPU 计算开放学习资料库，汇集用户指南、教程、示例、最佳实践和优化方法，覆盖 CUDA C++、加速 Python、标准并行、Warp、nvmath-python 与 GPU 部署，并提供可在 Brev 或 Colab 运行的交互式内容。 |
-| [CUDA 教程合集 - 比飞鸟贵重的多_HKL](https://space.bilibili.com/218427631/lists/4695308?type=series) | 视频合集 | 中文 CUDA 系列课程，从并行编程和 Kernel 基础逐步进入内存层次、常用算子实现与性能优化。 |
-| [CUDA Programming Course - High-Performance Computing with GPUs](https://www.youtube.com/watch?v=86FAWCzIe_4) | 视频课程 | 系统介绍 CUDA 编程模型、线程层次、GPU 内存、Kernel 编写和高性能计算中的常见优化方法。 |
-| [How to Optimize a CUDA Matmul Kernel for cuBLAS-like Performance: a Worklog](https://siboehm.com/articles/22/CUDA-MMM) | 博客 | 从朴素 SGEMM 开始，逐步加入合并访存、共享内存、Block Tiling、向量化、自动调优和 Warp Tiling，逼近 cuBLAS 性能。 |
-| [LeetCUDA](https://github.com/xlite-dev/LeetCUDA) | 资源合集 | 面向初学者的现代 CUDA 学习笔记，包含 PyTorch、200 多个 CUDA Kernel、Tensor Core、HGEMM 和 FA-2 MMA。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [NVIDIA Accelerated Computing Hub](https://github.com/NVIDIA/accelerated-computing-hub) | 资源合集 | NVIDIA 维护的 GPU 计算开放学习资料库，汇集用户指南、教程、示例、最佳实践和优化方法，覆盖 CUDA C++、加速 Python、标准并行、Warp、nvmath-python 与 GPU 部署，并提供可在 Brev 或 Colab 运行的交互式内容。 | |
+| [CUDA 教程合集 - 比飞鸟贵重的多_HKL](https://space.bilibili.com/218427631/lists/4695308?type=series) | 视频合集 | 中文 CUDA 系列课程，从并行编程和 Kernel 基础逐步进入内存层次、常用算子实现与性能优化。 | |
+| [CUDA Programming Course - High-Performance Computing with GPUs](https://www.youtube.com/watch?v=86FAWCzIe_4) | 视频课程 | 系统介绍 CUDA 编程模型、线程层次、GPU 内存、Kernel 编写和高性能计算中的常见优化方法。 | |
+| [How to Optimize a CUDA Matmul Kernel for cuBLAS-like Performance: a Worklog](https://siboehm.com/articles/22/CUDA-MMM) | 博客 | 从朴素 SGEMM 开始，逐步加入合并访存、共享内存、Block Tiling、向量化、自动调优和 Warp Tiling，逼近 cuBLAS 性能。 | |
+| [LeetCUDA](https://github.com/xlite-dev/LeetCUDA) | 资源合集 | 面向初学者的现代 CUDA 学习笔记，包含 PyTorch、200 多个 CUDA Kernel、Tensor Core、HGEMM 和 FA-2 MMA。 | |
 
 ## TileLang
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [TileLang Puzzles](https://github.com/tile-ai/tilelang-puzzles) | 实践项目 | 通过 10 个渐进式练习入门 TileLang，从基础操作逐步推进到 GEMM 和 FlashAttention。每道练习均可独立运行，并提供参考实现。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [TileLang Puzzles](https://github.com/tile-ai/tilelang-puzzles) | 实践项目 | 通过 10 个渐进式练习入门 TileLang，从基础操作逐步推进到 GEMM 和 FlashAttention。每道练习均可独立运行，并提供参考实现。 | |
 
 ## CUTLASS
 
-| 资源 | 类型 | 简介 | 配套资料 |
-|------|------|------|----------|
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
 | [Learn CUTLASS the Hard Way!](https://www.kapilsharma.dev/posts/learn-cutlass-the-hard-way/) | 博客 | 从朴素 FP32 GEMM 逐步推进到 BF16、Tensor Core、Swizzling、流水线、自动调优和 CUTLASS Kernel，并以 RTX 4090 为主要实验平台。 | [视频](https://www.youtube.com/watch?v=_ZOK0WmGm7o) |
 | [Learn CUTLASS the Hard Way - Part 2!](https://www.kapilsharma.dev/posts/learn-cutlass-the-hard-way-2/) | 博客 | 面向 H100 与 Hopper 架构，介绍 Thread Block Cluster、TMA、Warp Specialization 等特性，并使用 CUTLASS 优化 GEMM。 | |
 
 ## Triton
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [Deep Dive into Triton Internals (Part 1)](https://www.kapilsharma.dev/posts/deep-dive-into-triton-internals/) | 博客 | 总览 Triton 从 Python DSL 到 TTIR、TTGIR、LLVM IR、PTX 和 CUBIN 的编译与代码生成流程。 |
-| [Deep Dive into Triton Internals (Part 2)](https://www.kapilsharma.dev/posts/deep-dive-into-triton-internals-2/) | 博客 | 跟踪 `triton.compile` 在 Python 前端和 C++ 原生层中的调用路径，解释 AST Source、缓存键和编译阶段的组织方式。 |
-| [Deep Dive into Triton Internals (Part 3)](https://www.kapilsharma.dev/posts/deep-dive-into-triton-internals-3/) | 博客 | 深入 Triton 的 MLIR 后端，说明各类 Pass 如何逐步降低 IR 并生成面向 NVIDIA GPU 的代码。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [Deep Dive into Triton Internals (Part 1)](https://www.kapilsharma.dev/posts/deep-dive-into-triton-internals/) | 博客 | 总览 Triton 从 Python DSL 到 TTIR、TTGIR、LLVM IR、PTX 和 CUBIN 的编译与代码生成流程。 | |
+| [Deep Dive into Triton Internals (Part 2)](https://www.kapilsharma.dev/posts/deep-dive-into-triton-internals-2/) | 博客 | 跟踪 `triton.compile` 在 Python 前端和 C++ 原生层中的调用路径，解释 AST Source、缓存键和编译阶段的组织方式。 | |
+| [Deep Dive into Triton Internals (Part 3)](https://www.kapilsharma.dev/posts/deep-dive-into-triton-internals-3/) | 博客 | 深入 Triton 的 MLIR 后端，说明各类 Pass 如何逐步降低 IR 并生成面向 NVIDIA GPU 的代码。 | |
 
 ## FlashAttention
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [FlashAttention 为什么又快又节省 GPU 显存？](https://www.bilibili.com/video/BV1TU8x6hEVb)（[配套资料](https://zhangchitc.github.io/codex/078_flash_attention/visual.html)） | 视频 | 从 GPU 的 SRAM/HBM 存储层级和数据搬运成本出发，推导 Kernel Fusion、Online Softmax 与 Tiling 如何让 FlashAttention 在保持精确 Attention 计算的同时减少 HBM 读写和显存占用。 |
-| [FlashAttention from First Principles](https://ai.gopubby.com/flashattention-from-first-principles-part-1-5a9f2407d739#bypass) | 博客 | 从标准 Attention 的内存瓶颈出发，推导分块、Online Softmax 和避免物化完整注意力矩阵的实现思路。 |
-| [FlashAttention - Visually and Exhaustively Explained](https://ai.gopubby.com/flashattention-visually-and-exhaustively-explained-d6124670f7fb#bypass) | 博客 | 使用可视化示例解释 FlashAttention 的 Tiling、重计算、Online Softmax、前向与反向过程。 |
-| [Flash Attention 2.0 with Tri Dao](https://www.youtube.com/watch?v=IoMSGuiwV3g&t=2240s) | 视频 | Tri Dao 讲解 FlashAttention-2 的算法设计、并行划分、GPU 利用率和相对第一版的优化。 |
-| [Flash Attention 学习过程【详】解](https://www.bilibili.com/video/BV1FM9XYoEQ5) | 视频 | 中文讲解 FlashAttention 的计算流程、公式推导、分块策略和实现中的关键细节。 |
-| [ELI5: FlashAttention](https://gordicaleksa.medium.com/eli5-flash-attention-5c44017022ad) | 博客 | 以直观方式解释 Attention 的显存访问开销，以及 FlashAttention 如何通过 IO-aware 计算降低 HBM 读写。 |
-| [Designing Hardware-Aware Algorithms: FlashAttention](https://www.digitalocean.com/community/tutorials/flashattention) | 教程 | 从 GPU 内存层次和 Roofline 视角介绍硬件感知算法设计，并用 FlashAttention 展示计算与数据搬运的权衡。 |
-| [FlashAttention: Fast and Memory-Efficient Exact Attention With IO-Awareness](https://www.nvidia.com/en-us/on-demand/session/gtc24-s62546/) | 技术演讲 | NVIDIA GTC 演讲，系统介绍 IO-aware 精确 Attention、Kernel 实现与训练长上下文模型的性能收益。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [FlashAttention 为什么又快又节省 GPU 显存？](https://www.bilibili.com/video/BV1TU8x6hEVb) | 视频 | 从 GPU 的 SRAM/HBM 存储层级和数据搬运成本出发，推导 Kernel Fusion、Online Softmax 与 Tiling 如何让 FlashAttention 在保持精确 Attention 计算的同时减少 HBM 读写和显存占用。 | [配套资料](https://zhangchitc.github.io/codex/078_flash_attention/visual.html) |
+| [FlashAttention from First Principles](https://ai.gopubby.com/flashattention-from-first-principles-part-1-5a9f2407d739#bypass) | 博客 | 从标准 Attention 的内存瓶颈出发，推导分块、Online Softmax 和避免物化完整注意力矩阵的实现思路。 | |
+| [FlashAttention - Visually and Exhaustively Explained](https://ai.gopubby.com/flashattention-visually-and-exhaustively-explained-d6124670f7fb#bypass) | 博客 | 使用可视化示例解释 FlashAttention 的 Tiling、重计算、Online Softmax、前向与反向过程。 | |
+| [Flash Attention 2.0 with Tri Dao](https://www.youtube.com/watch?v=IoMSGuiwV3g&t=2240s) | 视频 | Tri Dao 讲解 FlashAttention-2 的算法设计、并行划分、GPU 利用率和相对第一版的优化。 | |
+| [Flash Attention 学习过程【详】解](https://www.bilibili.com/video/BV1FM9XYoEQ5) | 视频 | 中文讲解 FlashAttention 的计算流程、公式推导、分块策略和实现中的关键细节。 | |
+| [ELI5: FlashAttention](https://gordicaleksa.medium.com/eli5-flash-attention-5c44017022ad) | 博客 | 以直观方式解释 Attention 的显存访问开销，以及 FlashAttention 如何通过 IO-aware 计算降低 HBM 读写。 | |
+| [Designing Hardware-Aware Algorithms: FlashAttention](https://www.digitalocean.com/community/tutorials/flashattention) | 教程 | 从 GPU 内存层次和 Roofline 视角介绍硬件感知算法设计，并用 FlashAttention 展示计算与数据搬运的权衡。 | |
+| [FlashAttention: Fast and Memory-Efficient Exact Attention With IO-Awareness](https://www.nvidia.com/en-us/on-demand/session/gtc24-s62546/) | 技术演讲 | NVIDIA GTC 演讲，系统介绍 IO-aware 精确 Attention、Kernel 实现与训练长上下文模型的性能收益。 | |

--- a/resources/gpu-programming.mdx
+++ b/resources/gpu-programming.mdx
@@ -45,6 +45,8 @@ description: "GPU 架构、CUDA、Triton、CUTLASS、TileLang 与 FlashAttention
 
 | 资源 | 类型 | 简介 |
 |------|------|------|
+| [FlashAttention为什么又快又节省GPU显存？](https://www.bilibili.com/video/BV1TU8x6hEVb) | 视频 | 从 GPU 的 SRAM/HBM 存储层级和数据搬运成本出发，推导 Kernel Fusion、Online Softmax 与 Tiling 如何让 FlashAttention 在保持精确 Attention 计算的同时减少 HBM 读写和显存占用。 |
+| [FlashAttention：为什么加速推理的同时还能节省显存](https://zhangchitc.github.io/codex/078_flash_attention/visual.html) | 交互式可视化 | 通过八个交互式分屏展示 Attention 的矩阵计算、Kernel Fusion、Online Softmax 递推和 QKV Tiling，直观解释 FlashAttention 如何减少 HBM 数据搬运与中间结果存储。 |
 | [FlashAttention from First Principles](https://ai.gopubby.com/flashattention-from-first-principles-part-1-5a9f2407d739#bypass) | 博客 | 从标准 Attention 的内存瓶颈出发，推导分块、Online Softmax 和避免物化完整注意力矩阵的实现思路。 |
 | [FlashAttention - Visually and Exhaustively Explained](https://ai.gopubby.com/flashattention-visually-and-exhaustively-explained-d6124670f7fb#bypass) | 博客 | 使用可视化示例解释 FlashAttention 的 Tiling、重计算、Online Softmax、前向与反向过程。 |
 | [Flash Attention 2.0 with Tri Dao](https://www.youtube.com/watch?v=IoMSGuiwV3g&t=2240s) | 视频 | Tri Dao 讲解 FlashAttention-2 的算法设计、并行划分、GPU 利用率和相对第一版的优化。 |

--- a/resources/inference.mdx
+++ b/resources/inference.mdx
@@ -5,71 +5,71 @@ description: "LLM Serving、缓存、调度、PD 分离、推测解码与量化"
 
 ## 系统概览与实践
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [Time to First Token](https://github.com/patchy631/time-to-first-token) | 学习路线 | 一套为期 10 周、每天约 30 分钟的 LLM 推理 Serving 实践路线，以持续构建同一个 OpenAI 兼容服务为主线，覆盖 Roofline、vLLM、SGLang、可观测性、压测、量化、推测解码、KV Cache 淘汰、PD 分离、Kubernetes 与可复现 Benchmark。 |
-| [ai-inference-resources](https://github.com/aerlabsAI/ai-inference-resources) | 资源合集 | 面向 AI 推理系统工程师的精选资源合集，涵盖 LLM Serving、GPU Kernel 编程、Attention、量化、分布式推理和生产部署。 |
-| [Inside vLLM: Anatomy of a High-Throughput LLM Inference System](https://blog.vllm.ai/2025/09/05/anatomy-of-vllm.html) | 官方博客 | 从请求生命周期切入 vLLM，梳理输入处理、调度、模型执行、连续批处理和 KV Cache 管理等核心组件。 |
-| [vLLM 源码解析](https://zhuanlan.zhihu.com/p/691038809) | 博客 | 以源码为主线介绍 vLLM 的请求处理、调度器、Worker、模型执行和 PagedAttention 等实现。 |
-| [nano-vllm 源码解析](https://www.bilibili.com/video/BV1xY3wzZEFJ/?spm_id_from=333.337.search-card.all.click&vd_source=e9ad6164e9e6dacc7d15834004d914dc) | 视频 | 基于精简版 nano-vllm 拆解推理引擎的调度循环、KV Cache、批处理和模型执行流程。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [Time to First Token](https://github.com/patchy631/time-to-first-token) | 学习路线 | 一套为期 10 周、每天约 30 分钟的 LLM 推理 Serving 实践路线，以持续构建同一个 OpenAI 兼容服务为主线，覆盖 Roofline、vLLM、SGLang、可观测性、压测、量化、推测解码、KV Cache 淘汰、PD 分离、Kubernetes 与可复现 Benchmark。 | |
+| [ai-inference-resources](https://github.com/aerlabsAI/ai-inference-resources) | 资源合集 | 面向 AI 推理系统工程师的精选资源合集，涵盖 LLM Serving、GPU Kernel 编程、Attention、量化、分布式推理和生产部署。 | |
+| [Inside vLLM: Anatomy of a High-Throughput LLM Inference System](https://blog.vllm.ai/2025/09/05/anatomy-of-vllm.html) | 官方博客 | 从请求生命周期切入 vLLM，梳理输入处理、调度、模型执行、连续批处理和 KV Cache 管理等核心组件。 | |
+| [vLLM 源码解析](https://zhuanlan.zhihu.com/p/691038809) | 博客 | 以源码为主线介绍 vLLM 的请求处理、调度器、Worker、模型执行和 PagedAttention 等实现。 | |
+| [nano-vllm 源码解析](https://www.bilibili.com/video/BV1xY3wzZEFJ/?spm_id_from=333.337.search-card.all.click&vd_source=e9ad6164e9e6dacc7d15834004d914dc) | 视频 | 基于精简版 nano-vllm 拆解推理引擎的调度循环、KV Cache、批处理和模型执行流程。 | |
 
 ## Agent 推理
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [AgentX Industry Impact: Optimizations for Agentic Workloads](https://inferencex.semianalysis.com/agentx/optimizations) | 技术专题 | 汇总 AgentX 真实 Agent 推理负载推动的 50 余项上游优化，覆盖 vLLM、SGLang、TensorRT-LLM、Dynamo、LMCache 等项目的 KV Cache、路由、调度、卸载与数据传输。 |
-| [AgentX - InferenceXv3: Does CUDA Moat Hold up in Agentic Inferencing?](https://newsletter.semianalysis.com/p/agentx-inferencexv3-does-cuda-moat) | 行业分析 | 介绍 InferenceXv3 与 AgentX 的百万上下文、多轮 Agent 推理基准，分析 KV Cache 复用与卸载、路由、上下文并行及软硬件优化对真实负载性能的影响。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [AgentX Industry Impact: Optimizations for Agentic Workloads](https://inferencex.semianalysis.com/agentx/optimizations) | 技术专题 | 汇总 AgentX 真实 Agent 推理负载推动的 50 余项上游优化，覆盖 vLLM、SGLang、TensorRT-LLM、Dynamo、LMCache 等项目的 KV Cache、路由、调度、卸载与数据传输。 | |
+| [AgentX - InferenceXv3: Does CUDA Moat Hold up in Agentic Inferencing?](https://newsletter.semianalysis.com/p/agentx-inferencexv3-does-cuda-moat) | 行业分析 | 介绍 InferenceXv3 与 AgentX 的百万上下文、多轮 Agent 推理基准，分析 KV Cache 复用与卸载、路由、上下文并行及软硬件优化对真实负载性能的影响。 | |
 
 ## KV Cache
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [LMCache 技术：计算与存储解耦下的分布式缓存演进](https://mp.weixin.qq.com/s/jt3FP6WoQHDGGNVAKr0wKg) | 论文合集 | 以 LMCache 为主线串联 CacheGen、CacheBlend、TraCT 等相关工作，梳理 KV Cache 压缩、知识融合、传输与分布式缓存系统的演进。 |
-| [KV Cache Compression and Its Infra Problems](https://research.nvidia.com/labs/eai/blogs/kv-cache-compression-and-its-infra-problems/) | 官方博客 | 从基础设施视角梳理 KV Cache 压缩，分析 FlashAttention 不暴露 Attention Score、PagedAttention 块内碎片使逻辑淘汰无法回收显存两类落地问题，并介绍 TriAttention 与 Forward-Packing Compaction 的解决思路。 |
-| [KV Caching in LLMs, Clearly Explained](https://x.com/akshay_pachaar/status/2020840784782913605) | X 文章 | 从自回归生成与 Attention 计算出发，解释 KV Cache 如何复用历史 K/V、消除重复投影计算，以及 Prefill、TTFT、显存开销、上下文长度与 GQA/MQA 之间的权衡。 |
-| [Efficient Memory Management for Large Language Model Serving with PagedAttention](https://arxiv.org/abs/2309.06180) | 论文 | 提出 PagedAttention，以分页方式管理非连续 KV Cache，减少内存碎片和冗余复制，是 vLLM 高吞吐 Serving 的核心工作。 |
-| [CacheBlend: Fast Large Language Model Serving for RAG with Cached Knowledge Fusion](https://arxiv.org/abs/2405.16444) | 论文 | 复用不同知识块的 KV Cache，并选择性重算少量 Token 以融合跨块注意力，在保持生成质量的同时降低 RAG 的 TTFT。 |
-| [SnapKV: LLM Knows What You are Looking for Before Generation](https://arxiv.org/abs/2404.14469) | 论文 | 从提示末尾的观察窗口识别各 Attention Head 关注的位置，仅保留聚类后的重要 KV，在无需微调的情况下压缩长上下文 KV Cache。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [LMCache 技术：计算与存储解耦下的分布式缓存演进](https://mp.weixin.qq.com/s/jt3FP6WoQHDGGNVAKr0wKg) | 论文合集 | 以 LMCache 为主线串联 CacheGen、CacheBlend、TraCT 等相关工作，梳理 KV Cache 压缩、知识融合、传输与分布式缓存系统的演进。 | |
+| [KV Cache Compression and Its Infra Problems](https://research.nvidia.com/labs/eai/blogs/kv-cache-compression-and-its-infra-problems/) | 官方博客 | 从基础设施视角梳理 KV Cache 压缩，分析 FlashAttention 不暴露 Attention Score、PagedAttention 块内碎片使逻辑淘汰无法回收显存两类落地问题，并介绍 TriAttention 与 Forward-Packing Compaction 的解决思路。 | |
+| [KV Caching in LLMs, Clearly Explained](https://x.com/akshay_pachaar/status/2020840784782913605) | X 文章 | 从自回归生成与 Attention 计算出发，解释 KV Cache 如何复用历史 K/V、消除重复投影计算，以及 Prefill、TTFT、显存开销、上下文长度与 GQA/MQA 之间的权衡。 | |
+| [Efficient Memory Management for Large Language Model Serving with PagedAttention](https://arxiv.org/abs/2309.06180) | 论文 | 提出 PagedAttention，以分页方式管理非连续 KV Cache，减少内存碎片和冗余复制，是 vLLM 高吞吐 Serving 的核心工作。 | |
+| [CacheBlend: Fast Large Language Model Serving for RAG with Cached Knowledge Fusion](https://arxiv.org/abs/2405.16444) | 论文 | 复用不同知识块的 KV Cache，并选择性重算少量 Token 以融合跨块注意力，在保持生成质量的同时降低 RAG 的 TTFT。 | |
+| [SnapKV: LLM Knows What You are Looking for Before Generation](https://arxiv.org/abs/2404.14469) | 论文 | 从提示末尾的观察窗口识别各 Attention Head 关注的位置，仅保留聚类后的重要 KV，在无需微调的情况下压缩长上下文 KV Cache。 | |
 
 ## 调度与批处理
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [SARATHI: Efficient LLM Inference by Piggybacking Decodes with Chunked Prefills](https://arxiv.org/abs/2308.16369) | 论文 | 将长 Prefill 切成固定大小的块，并在每个块中搭载 Decode 请求，以降低流水线气泡和批次间计算量波动。 |
-| [Taming Throughput-Latency Tradeoff in LLM Inference with Sarathi-Serve](https://arxiv.org/abs/2403.02310) | 论文 | 将 Chunked Prefill 与无停顿调度结合，在控制 Time Between Tokens 的同时提升吞吐并降低 Prefill 对 Decode 的干扰。 |
-| [DeepSpeed-FastGen: High-throughput Text Generation for LLMs](https://arxiv.org/abs/2401.08671) | 论文 | 介绍 Dynamic SplitFuse、DeepSpeed-Inference 和 MII，通过动态组合 Prefill 与 Decode 工作提升生成吞吐和响应性。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [SARATHI: Efficient LLM Inference by Piggybacking Decodes with Chunked Prefills](https://arxiv.org/abs/2308.16369) | 论文 | 将长 Prefill 切成固定大小的块，并在每个块中搭载 Decode 请求，以降低流水线气泡和批次间计算量波动。 | |
+| [Taming Throughput-Latency Tradeoff in LLM Inference with Sarathi-Serve](https://arxiv.org/abs/2403.02310) | 论文 | 将 Chunked Prefill 与无停顿调度结合，在控制 Time Between Tokens 的同时提升吞吐并降低 Prefill 对 Decode 的干扰。 | |
+| [DeepSpeed-FastGen: High-throughput Text Generation for LLMs](https://arxiv.org/abs/2401.08671) | 论文 | 介绍 Dynamic SplitFuse、DeepSpeed-Inference 和 MII，通过动态组合 Prefill 与 Decode 工作提升生成吞吐和响应性。 | |
 
 ## PD 分离
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [DistServe: Disaggregating Prefill and Decoding for Goodput-optimized Large Language Model Serving](https://arxiv.org/abs/2401.09670) | 论文 | 将 Prefill 与 Decode 放到不同 GPU，并分别优化资源分配和并行策略，以同时满足 TTFT 与 TPOT 的服务目标。 |
-| [Splitwise: Efficient Generative LLM Inference Using Phase Splitting](https://arxiv.org/abs/2311.18677) | 论文 | 根据 Prefill 的计算密集特征和 Decode 的内存密集特征拆分硬件池，实现分阶段独立扩缩容和异构资源配置。 |
-| [TetriInfer: Inference without Interference](https://arxiv.org/abs/2401.11181) | 论文 | 结合固定大小的 Prompt 分块、Prefill-Decode 分离和资源预测驱动的两级调度，减少混合工作负载之间的干扰。 |
-| [MemServe: Context Caching for Disaggregated LLM Serving with Elastic Memory Pool](https://arxiv.org/abs/2406.17565) | 论文 | 通过弹性分布式内存池统一管理 KV Cache，把跨请求上下文缓存与 Prefill-Decode 分离结合起来。 |
-| [Mooncake: A KVCache-centric Disaggregated Architecture](https://arxiv.org/abs/2407.00079) | 论文 | Kimi 的 KV Cache 中心化推理架构，分离 Prefill 与 Decode 集群，并利用 CPU、DRAM 和 SSD 构建分布式 KV Cache。 |
-| [DualPath: Breaking the Storage Bandwidth Bottleneck in Agentic LLM Inference](https://arxiv.org/abs/2602.21548) | 论文 | 为多轮 Agent 推理增加 Storage-to-Decode KV Cache 加载路径，并用全局调度平衡 Prefill 与 Decode 侧的存储带宽。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [DistServe: Disaggregating Prefill and Decoding for Goodput-optimized Large Language Model Serving](https://arxiv.org/abs/2401.09670) | 论文 | 将 Prefill 与 Decode 放到不同 GPU，并分别优化资源分配和并行策略，以同时满足 TTFT 与 TPOT 的服务目标。 | |
+| [Splitwise: Efficient Generative LLM Inference Using Phase Splitting](https://arxiv.org/abs/2311.18677) | 论文 | 根据 Prefill 的计算密集特征和 Decode 的内存密集特征拆分硬件池，实现分阶段独立扩缩容和异构资源配置。 | |
+| [TetriInfer: Inference without Interference](https://arxiv.org/abs/2401.11181) | 论文 | 结合固定大小的 Prompt 分块、Prefill-Decode 分离和资源预测驱动的两级调度，减少混合工作负载之间的干扰。 | |
+| [MemServe: Context Caching for Disaggregated LLM Serving with Elastic Memory Pool](https://arxiv.org/abs/2406.17565) | 论文 | 通过弹性分布式内存池统一管理 KV Cache，把跨请求上下文缓存与 Prefill-Decode 分离结合起来。 | |
+| [Mooncake: A KVCache-centric Disaggregated Architecture](https://arxiv.org/abs/2407.00079) | 论文 | Kimi 的 KV Cache 中心化推理架构，分离 Prefill 与 Decode 集群，并利用 CPU、DRAM 和 SSD 构建分布式 KV Cache。 | |
+| [DualPath: Breaking the Storage Bandwidth Bottleneck in Agentic LLM Inference](https://arxiv.org/abs/2602.21548) | 论文 | 为多轮 Agent 推理增加 Storage-to-Decode KV Cache 加载路径，并用全局调度平衡 Prefill 与 Decode 侧的存储带宽。 | |
 
 ## 推测解码
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [Fast Inference from Transformers via Speculative Decoding](https://arxiv.org/abs/2211.17192) | 论文 | 让较小的 Draft Model 一次提出多个候选 Token，再由目标模型并行验证，在不改变输出分布的前提下减少串行解码步骤。 |
-| [Accelerating Large Language Model Decoding with Speculative Sampling](https://arxiv.org/abs/2302.01318) | 论文 | 给出 Speculative Sampling 算法和理论分析，通过近似模型生成候选并由目标模型校正，实现无损采样加速。 |
-| [Break the Sequential Dependency of LLM Inference Using Lookahead Decoding](https://arxiv.org/abs/2402.02057) | 论文 | 利用 Jacobi 迭代并行发现和验证高质量 N-gram，不依赖额外 Draft Model，减少自回归解码的串行依赖。 |
-| [Medusa: Simple LLM Inference Acceleration Framework with Multiple Decoding Heads](https://arxiv.org/abs/2401.10774) | 论文 | 在原模型上增加多个解码头预测后续 Token，并通过 Tree Attention 并行验证候选，避免部署独立 Draft Model。 |
-| [How Speculative Decoding Boosts vLLM Performance by up to 2.8x](https://blog.vllm.ai/2024/10/17/spec-decode.html) | 官方博客 | 介绍 vLLM 中推测解码的实现、配置、适用工作负载和基准结果，说明加速收益与开销的来源。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [Fast Inference from Transformers via Speculative Decoding](https://arxiv.org/abs/2211.17192) | 论文 | 让较小的 Draft Model 一次提出多个候选 Token，再由目标模型并行验证，在不改变输出分布的前提下减少串行解码步骤。 | |
+| [Accelerating Large Language Model Decoding with Speculative Sampling](https://arxiv.org/abs/2302.01318) | 论文 | 给出 Speculative Sampling 算法和理论分析，通过近似模型生成候选并由目标模型校正，实现无损采样加速。 | |
+| [Break the Sequential Dependency of LLM Inference Using Lookahead Decoding](https://arxiv.org/abs/2402.02057) | 论文 | 利用 Jacobi 迭代并行发现和验证高质量 N-gram，不依赖额外 Draft Model，减少自回归解码的串行依赖。 | |
+| [Medusa: Simple LLM Inference Acceleration Framework with Multiple Decoding Heads](https://arxiv.org/abs/2401.10774) | 论文 | 在原模型上增加多个解码头预测后续 Token，并通过 Tree Attention 并行验证候选，避免部署独立 Draft Model。 | |
+| [How Speculative Decoding Boosts vLLM Performance by up to 2.8x](https://blog.vllm.ai/2024/10/17/spec-decode.html) | 官方博客 | 介绍 vLLM 中推测解码的实现、配置、适用工作负载和基准结果，说明加速收益与开销的来源。 | |
 
 ## 量化
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [PyTorch 官方量化资料](https://docs.pytorch.org/docs/main/quantization.html#introduction-to-quantization) | 官方文档 | 汇总 PyTorch 量化的核心概念、后训练量化、量化感知训练、相关 API 和后端支持。 |
-| [PyTorch 量化实战项目](https://github.com/Laicheng0830/Pytorch_Model_Quantization/blob/main/pose_estimation.py) | 实践项目 | 以姿态估计模型为例演示 PyTorch 模型量化、校准、转换和量化前后的推理结果比较。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [PyTorch 官方量化资料](https://docs.pytorch.org/docs/main/quantization.html#introduction-to-quantization) | 官方文档 | 汇总 PyTorch 量化的核心概念、后训练量化、量化感知训练、相关 API 和后端支持。 | |
+| [PyTorch 量化实战项目](https://github.com/Laicheng0830/Pytorch_Model_Quantization/blob/main/pose_estimation.py) | 实践项目 | 以姿态估计模型为例演示 PyTorch 模型量化、校准、转换和量化前后的推理结果比较。 | |
 
 ## LLM 应用系统
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [Parrot: Efficient Serving of LLM-based Applications with Semantic Variable](https://arxiv.org/abs/2405.19888) | 论文 | 用 Semantic Variable 暴露多个 LLM 请求之间的数据流关系，让 Serving 系统执行跨请求分析、调度和缓存优化。 |
-| [Teola: Towards End-to-End Optimization of LLM-based Applications](https://arxiv.org/abs/2407.00326) | 论文 | 将应用工作流表示为细粒度数据流图，跨 LLM 与非 LLM 组件执行并行、流水线和端到端调度优化。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [Parrot: Efficient Serving of LLM-based Applications with Semantic Variable](https://arxiv.org/abs/2405.19888) | 论文 | 用 Semantic Variable 暴露多个 LLM 请求之间的数据流关系，让 Serving 系统执行跨请求分析、调度和缓存优化。 | |
+| [Teola: Towards End-to-End Optimization of LLM-based Applications](https://arxiv.org/abs/2407.00326) | 论文 | 将应用工作流表示为细粒度数据流图，跨 LLM 与非 LLM 组件执行并行、流水线和端到端调度优化。 | |

--- a/resources/llm-foundations.mdx
+++ b/resources/llm-foundations.mdx
@@ -5,16 +5,16 @@ description: "Transformer、GPT 实现与语言模型入门课程"
 
 ## 入门课程
 
-| 资源 | 类型 | 简介 | 配套资料 |
-|------|------|------|----------|
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
 | [CSCI 1390, Spring 2025: Systems for Machine Learning](https://cs.brown.edu/courses/csci1390/) | 课程 | 主题包括高效训练和推理、ML 算法与硬件、GPU 编程、CUDA、Transformer 架构和高效检索。 | |
 | [CS336: Language Modeling from Scratch (Stanford / Spring 2025)](https://cs336.stanford.edu/spring2025/index.html) | 课程 | 从 tokenizer、Transformer 到分布式训练、数据处理和 RLHF 对齐，5 个实战 assignment 覆盖 LLM 全链路。 | [视频](https://www.bilibili.com/video/BV1zvt9zKEK6) |
 | [The Smol Training Playbook](https://huggingface.co/spaces/HuggingFaceTB/smol-training-playbook) | 教程 | 以 SmolLM3 的真实训练过程为主线，覆盖模型目标与规模选择、架构和数据配比、消融实验、分布式预训练、监控排障、评测及后训练。 | |
 
 ## 从零构建 GPT
 
-| 资源 | 类型 | 简介 | 配套资料 |
-|------|------|------|----------|
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
 | [Build a Large Language Model (From Scratch)](https://www.manning.com/books/build-a-large-language-model-from-scratch) | 书籍 | 从零规划并编写 LLM 的各个组件，涵盖数据集准备、文本分类微调、指令对齐和加载预训练权重。 | [GitHub](https://github.com/rasbt/LLMs-from-scratch) |
 | [nanoGPT](https://github.com/karpathy/nanoGPT) | 实践项目 | 精简的 PyTorch GPT 训练与微调实现，可从字符级 toy GPT 入门，并进一步复现 GPT-2 124M，重点是理解语言模型的预训练过程。 | [视频](https://www.youtube.com/watch?v=kCc8FmEb1nY) |
 | [nanochat](https://github.com/karpathy/nanochat) | 实践项目 | nanoGPT 的后续项目，以单节点可运行、易修改的代码覆盖 tokenizer、预训练、微调、评测和推理，形成一个可实际对话的端到端 ChatGPT 训练流程。 | |

--- a/resources/performance-analysis.mdx
+++ b/resources/performance-analysis.mdx
@@ -5,20 +5,20 @@ description: "训练与推理的 Roofline、Benchmark、Nsight 和 Profiling 资
 
 ## 体系化学习
 
-| 资源 | 类型 | 简介 | 配套资料 |
-|------|------|------|----------|
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
 | [AI Systems Performance Engineering](https://www.oreilly.com/library/view/ai-systems-performance/9798341627772/) | 书籍 | 讲解 GPU CUDA Kernel 调优、PyTorch 算法优化、多节点训练和推理系统优化，并附有 175 多项实战优化清单。 | [GitHub](https://github.com/cfregly/ai-performance-engineering) |
 | [How to Scale Your Model](https://jax-ml.github.io/scaling-book/) | 在线书籍 | 涵盖 Roofline 分析、硬件互连、Transformer 计算与内存、并行策略，以及训练和推理的性能分析。 | [GitHub](https://github.com/jax-ml/scaling-book) |
 | [CSCI 1390, Spring 2025: Systems for Machine Learning](https://cs.brown.edu/courses/csci1390/) | 课程 | 主题包括高效训练和推理、ML 算法性能、GPU 编程、CUDA 和 Transformer 架构。 | |
 
 ## 训练性能
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [Stanford CS336 Assignment 2: Systems](https://github.com/stanford-cs336/assignment2-systems/tree/main) | 实践课程 | 围绕 Transformer 训练系统实践性能基准测试、分析与优化，并实现分布式训练。整体计算资源要求不高，强烈推荐完整完成。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [Stanford CS336 Assignment 2: Systems](https://github.com/stanford-cs336/assignment2-systems/tree/main) | 实践课程 | 围绕 Transformer 训练系统实践性能基准测试、分析与优化，并实现分布式训练。整体计算资源要求不高，强烈推荐完整完成。 | |
 
 ## Profiling 工具
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [PyTorch Profiling with NVIDIA Nsight](https://docs.lxp.lu/howto/pytorch-profiling-with-nsight/) | 教程 | 详细讲解 Nsight Systems 和 Nsight Compute 的分工、报告采集、CLI 与 UI 分析、NVTX 标记、时间线解读，以及 PyTorch 常见性能瓶颈的诊断与优化。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [PyTorch Profiling with NVIDIA Nsight](https://docs.lxp.lu/howto/pytorch-profiling-with-nsight/) | 教程 | 详细讲解 Nsight Systems 和 Nsight Compute 的分工、报告采集、CLI 与 UI 分析、NVTX 标记、时间线解读，以及 PyTorch 常见性能瓶颈的诊断与优化。 | |

--- a/resources/rag.mdx
+++ b/resources/rag.mdx
@@ -5,13 +5,13 @@ description: "检索增强生成的检索、上下文管理、Serving 与评测�
 
 ## Graph RAG
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [Vector \| Graph：蚂蚁首个开源 Graph RAG 框架设计解读](https://mp.weixin.qq.com/s/WILvYFiKugroy9Q_FmGriA) | 技术解读 | 对比 Vector RAG 与 Graph RAG 在索引、检索和生成阶段的数据流，介绍由 DB-GPT、OpenSPG 和 TuGraph 组成的开源方案及关键接口。 |
-| [论文解读｜全球首篇 GraphRAG Survey 的官方解读来啦](https://mp.weixin.qq.com/s/Dx8pYhmbrhtRMXNez_GOmw) | 综述解读 | 解读 [Graph Retrieval-Augmented Generation: A Survey](https://arxiv.org/abs/2408.08921)，按照图索引、图检索和图增强生成三个阶段梳理技术路线，并覆盖训练、应用、评测和工业实现。配套资料见 [GraphRAG-Survey](https://github.com/pengboci/GraphRAG-Survey)。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [Vector \| Graph：蚂蚁首个开源 Graph RAG 框架设计解读](https://mp.weixin.qq.com/s/WILvYFiKugroy9Q_FmGriA) | 技术解读 | 对比 Vector RAG 与 Graph RAG 在索引、检索和生成阶段的数据流，介绍由 DB-GPT、OpenSPG 和 TuGraph 组成的开源方案及关键接口。 | |
+| [论文解读｜全球首篇 GraphRAG Survey 的官方解读来啦](https://mp.weixin.qq.com/s/Dx8pYhmbrhtRMXNez_GOmw) | 综述解读 | 解读 Graph Retrieval-Augmented Generation: A Survey，按照图索引、图检索和图增强生成三个阶段梳理技术路线，并覆盖训练、应用、评测和工业实现。配套资料见 GraphRAG-Survey。 | [Graph Retrieval-Augmented Generation: A Survey](https://arxiv.org/abs/2408.08921) · [GraphRAG-Survey](https://github.com/pengboci/GraphRAG-Survey) |
 
 ## RAG Serving 与系统优化
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [METIS: Fast Quality-Aware RAG Systems with Configuration Adaptation](https://arxiv.org/abs/2412.10543) | 论文 | 联合调度查询并按请求调整检索块数量和答案合成策略，在生成质量与响应延迟之间动态权衡。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [METIS: Fast Quality-Aware RAG Systems with Configuration Adaptation](https://arxiv.org/abs/2412.10543) | 论文 | 联合调度查询并按请求调整检索块数量和答案合成策略，在生成质量与响应延迟之间动态权衡。 | |

--- a/resources/rl.mdx
+++ b/resources/rl.mdx
@@ -5,7 +5,7 @@ description: "RLHF、Agentic RL 与强化学习训练系统资源"
 
 ## RL 系统与基础设施
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [Awesome-ML-SYS-Tutorial（中文版）](https://github.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/blob/main/README-cn.md) | 学习笔记合集 | 以 RL Infra 为主线的中文 ML Systems 学习笔记，涵盖 slime、AReaL、verl、OpenRLHF、Agentic RL、训推一致性、权重更新、FSDP/Megatron 训练后端，并延伸到 SGLang 推理系统与 AI Infra 基础 |
-| [Accio-Lab/Dressage](https://github.com/Accio-Lab/Dressage) | 开源框架 | 基于 slime 的 Agentic RL 训练框架，打通策略 Rollout、Sandbox 工具执行、Token 级轨迹记录和训练样本转换，统一支持 Python 白盒工具循环与 Codex、Claude Code 等 HTTP 黑盒 Agent。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [Awesome-ML-SYS-Tutorial（中文版）](https://github.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/blob/main/README-cn.md) | 学习笔记合集 | 以 RL Infra 为主线的中文 ML Systems 学习笔记，涵盖 slime、AReaL、verl、OpenRLHF、Agentic RL、训推一致性、权重更新、FSDP/Megatron 训练后端，并延伸到 SGLang 推理系统与 AI Infra 基础 | |
+| [Accio-Lab/Dressage](https://github.com/Accio-Lab/Dressage) | 开源框架 | 基于 slime 的 Agentic RL 训练框架，打通策略 Rollout、Sandbox 工具执行、Token 级轨迹记录和训练样本转换，统一支持 Python 白盒工具循环与 Codex、Claude Code 等 HTTP 黑盒 Agent。 | |

--- a/resources/training.mdx
+++ b/resources/training.mdx
@@ -10,7 +10,7 @@ description: "LLM 预训练、Scaling、分布式训练与训练基础设施"
 | [How to Scale Your Model](https://jax-ml.github.io/scaling-book/) | 在线书籍 | 从系统视角讲解 LLM 在 TPU 和 GPU 上的训练与推理扩展，涵盖 Roofline 分析、硬件互连、Transformer 计算与内存、并行策略，以及基于 JAX 的性能分析与编程实践。 | [GitHub](https://github.com/jax-ml/scaling-book) |
 | [Awesome-LM-Architecture](https://github.com/Superposition09m/Awesome-LM-Architecture) | 资源合集 | 按核心组件、模型架构、扩展与预训练、模型技术报告整理语言模型架构，涵盖位置编码、归一化、Attention、线性模型、Test-Time Learning、MoE 和 Scaling Laws。 | |
 
-## 预训练与基础设施
+## 预训练
 
 | 资源 | 类型 | 简介 | 配套资料 |
 |------|------|------|----------|

--- a/resources/training.mdx
+++ b/resources/training.mdx
@@ -12,9 +12,10 @@ description: "LLM 预训练、Scaling、分布式训练与训练基础设施"
 
 ## 预训练与基础设施
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [MAI-Thinking-1: Building a Hill-Climbing Machine](https://microsoft.ai/pdf/mai-thinking-1.pdf) | 技术报告 | 微软 MAI-Thinking-1 技术报告，涵盖 MoE 架构、Scaling Ladder、预训练数据、长周期 RL、评测以及大规模训练和推理基础设施。 |
+| 资源 | 类型 | 简介 | 配套资料 |
+|------|------|------|----------|
+| [Marin](https://github.com/marin-community/marin) | 开源项目 | 公开开发的大模型训练项目与软件平台，覆盖数据整理、转换、过滤、去重、分词、预训练、后训练与评测，并公开代码、数据来源、模型权重以及成功和失败的实验记录。 | [官方网站](https://marin.community/) · [官方文档](https://marin.readthedocs.io/en/latest/) |
+| [MAI-Thinking-1: Building a Hill-Climbing Machine](https://microsoft.ai/pdf/mai-thinking-1.pdf) | 技术报告 | 微软 MAI-Thinking-1 技术报告，涵盖 MoE 架构、Scaling Ladder、预训练数据、长周期 RL、评测以及大规模训练和推理基础设施。 | |
 
 ## Test-Time Training
 

--- a/resources/training.mdx
+++ b/resources/training.mdx
@@ -5,20 +5,20 @@ description: "LLM 预训练、Scaling、分布式训练与训练基础设施"
 
 ## 模型架构与 Scaling
 
-| 资源 | 类型 | 简介 | 配套资料 |
-|------|------|------|----------|
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
 | [How to Scale Your Model](https://jax-ml.github.io/scaling-book/) | 在线书籍 | 从系统视角讲解 LLM 在 TPU 和 GPU 上的训练与推理扩展，涵盖 Roofline 分析、硬件互连、Transformer 计算与内存、并行策略，以及基于 JAX 的性能分析与编程实践。 | [GitHub](https://github.com/jax-ml/scaling-book) |
 | [Awesome-LM-Architecture](https://github.com/Superposition09m/Awesome-LM-Architecture) | 资源合集 | 按核心组件、模型架构、扩展与预训练、模型技术报告整理语言模型架构，涵盖位置编码、归一化、Attention、线性模型、Test-Time Learning、MoE 和 Scaling Laws。 | |
 
 ## 预训练
 
-| 资源 | 类型 | 简介 | 配套资料 |
-|------|------|------|----------|
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
 | [Marin](https://github.com/marin-community/marin) | 开源项目 | 公开开发的大模型训练项目与软件平台，覆盖数据整理、转换、过滤、去重、分词、预训练、后训练与评测，并公开代码、数据来源、模型权重以及成功和失败的实验记录。 | [官方网站](https://marin.community/) · [官方文档](https://marin.readthedocs.io/en/latest/) |
 | [MAI-Thinking-1: Building a Hill-Climbing Machine](https://microsoft.ai/pdf/mai-thinking-1.pdf) | 技术报告 | 微软 MAI-Thinking-1 技术报告，涵盖 MoE 架构、Scaling Ladder、预训练数据、长周期 RL、评测以及大规模训练和推理基础设施。 | |
 
 ## Test-Time Training
 
-| 资源 | 类型 | 简介 |
-|------|------|------|
-| [Test-Time Training Done Right](https://arxiv.org/abs/2505.23884) | 论文 | 提出 Large Chunk Test-Time Training，通过大块在线更新提升 GPU 利用率和非线性状态容量，并将测试时训练扩展到语言、图像与视频的长上下文任务。 |
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [Test-Time Training Done Right](https://arxiv.org/abs/2505.23884) | 论文 | 提出 Large Chunk Test-Time Training，通过大块在线更新提升 GPU 利用率和非线性状态容量，并将测试时训练扩展到语言、图像与视频的长上下文任务。 | |


### PR DESCRIPTION
## Summary

- add a Chinese video explaining FlashAttention through GPU memory hierarchy, kernel fusion, online softmax, and tiling
- link its companion visualization from the Materials column
- add Marin to Learning Resources > Training as an open foundation model training project
- group the Marin GitHub repository, official website, and documentation in one resource entry
- standardize all 35 resource tables to the four-column Resource / Type / Description / Materials schema (`资源 | 类型 | 简介 | 资料`)
- move companion links into the Materials column while preserving existing content and URLs

## Validation

- verified 35 tables and 102 rows against the four-column schema
- `mint broken-links`
- `mint validate`