### PR TITLE
doc: add TorchFT training resource

### DIFF
--- a/resources/training.mdx
+++ b/resources/training.mdx
@@ -17,6 +17,12 @@ description: "LLM 预训练、Scaling、分布式训练与训练基础设施"
 | [Marin](https://github.com/marin-community/marin) | 开源项目 | 公开开发的大模型训练项目与软件平台，覆盖数据整理、转换、过滤、去重、分词、预训练、后训练与评测，并公开代码、数据来源、模型权重以及成功和失败的实验记录。 | [官方网站](https://marin.community/) · [官方文档](https://marin.readthedocs.io/en/latest/) |
 | [MAI-Thinking-1: Building a Hill-Climbing Machine](https://microsoft.ai/pdf/mai-thinking-1.pdf) | 技术报告 | 微软 MAI-Thinking-1 技术报告，涵盖 MoE 架构、Scaling Ladder、预训练数据、长周期 RL、评测以及大规模训练和推理基础设施。 | |
 
+## 分布式训练与容错
+
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [TorchFT](https://github.com/meta-pytorch/torchft) | 开源项目 | 面向 PyTorch 分布式训练的 Step 级容错库，为 DDP 和 HSDP 提供健康检测、ProcessGroup 重构及健康副本状态恢复，使部分副本故障后训练继续推进。 | [官方文档](https://meta-pytorch.org/torchft/) |
+
 ## Test-Time Training
 
 | 资源 | 类型 | 简介 | 资料 |


### PR DESCRIPTION
## Summary

- add a Distributed Training and Fault Tolerance section to the training resources page
- add TorchFT with a concise description of its step-level DDP/HSDP fault-tolerance capabilities
- link the official TorchFT documentation in the materials column

## Validation

- verified the GitHub repository and official documentation return HTTP 200
- verified the four-column resource table schema
- `mint validate`
- `mint broken-links`
- `git diff --check`
