### PR TITLE
docs: organize RL resources and training projects

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -111,6 +111,7 @@
           {
             "group": "主题分类",
             "pages": [
+              "projects/training",
               "projects/llm-gateway",
               "projects/inference",
               "projects/performance",

--- a/projects/training.mdx
+++ b/projects/training.mdx
@@ -1,0 +1,10 @@
+---
+title: "训练"
+description: "预训练、后训练、分布式训练与训练基础设施项目"
+---
+
+## RL 训练
+
+| 项目 | 简介 | 参考资料 |
+|------|------|----------|
+| [Accio-Lab/Dressage](https://github.com/Accio-Lab/Dressage) | 基于 slime 的 Agentic RL 训练框架，通过统一的 Proxy 与 Paddock 层连接 Agent Rollout、Sandbox 工具执行、Token 级轨迹记录和训练样本转换，并支持 Python 白盒工具循环与 Codex、Claude Code 等 HTTP 黑盒 Agent。 | [快速开始](https://github.com/Accio-Lab/Dressage/blob/main/docs/quickstart.md) · [训练机制](https://github.com/Accio-Lab/Dressage/blob/main/docs/training.md) · [训练配方](https://github.com/Accio-Lab/Dressage/blob/main/docs/recipes.md) |

--- a/resources/rl.mdx
+++ b/resources/rl.mdx
@@ -3,21 +3,11 @@ title: "RL"
 description: "强化学习基础、大模型后训练与强化学习训练系统资源"
 ---
 
-## 强化学习基础
+## 强化学习
 
 | 资源 | 类型 | 简介 | 资料 |
 |------|------|------|------|
 | [强化学习的数学原理](https://github.com/MathFoundationRL/Book-Mathematical-Foundation-of-Reinforcement-Learning) | 教材 / 课程 | 西湖大学赵世钰从数学角度讲解强化学习，覆盖贝尔曼方程、值迭代、策略迭代、Monte Carlo、时序差分、Sarsa、Q-learning、值函数近似、策略梯度与 Actor-Critic，并以 Grid World 串联概念和算法。 | [英文教材 PDF](https://github.com/MathFoundationRL/Book-Mathematical-Foundation-of-Reinforcement-Learning/blob/main/Book-all-in-one.pdf) · [中文版（清华大学出版社）](https://www.tup.tsinghua.edu.cn/bookscenter/book_10986001.html) · [课件](https://github.com/MathFoundationRL/Book-Mathematical-Foundation-of-Reinforcement-Learning/tree/main/Lecture%20slides/slidesContinuouslyUpdated) · [中文视频](https://www.bilibili.com/video/BV1sd4y167NS/) |
 | [动手学强化学习](https://hrl.boyuai.com/) | 教程 | 张伟楠、沈键、俞勇编写的中文教程，通过图文和 Jupyter Notebook 实现动态规划、时序差分、DQN、Actor-Critic、PPO、DDPG 与 SAC，并延伸到模仿学习、离线 RL 和多智能体 RL。 | [代码](https://github.com/boyu-ai/Hands-on-RL) · [视频课程](https://www.boyuai.com/elites/course/xVqhU42F5IDky94x) |
-
-## 大模型强化学习
-
-| 资源 | 类型 | 简介 | 资料 |
-|------|------|------|------|
 | [Hands-on Modern RL](https://walkinglabs.github.io/hands-on-modern-rl/) | 开源教程 | 以可运行代码串联经典强化学习、大模型后训练与 Agentic RL，覆盖 DQN、Actor-Critic、PPO、RLHF、DPO、GRPO、RLVR、推理模型及工具调用智能体；项目仍在持续更新，仓库提示内容尚未全面审稿。 | [GitHub](https://github.com/walkinglabs/hands-on-modern-rl) · [PDF / EPUB](https://github.com/walkinglabs/hands-on-modern-rl/releases/latest) |
-
-## RL 系统与基础设施
-
-| 资源 | 类型 | 简介 | 资料 |
-|------|------|------|------|
 | [Awesome-ML-SYS-Tutorial（中文版）](https://github.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/blob/main/README-cn.md) | 学习笔记合集 | 以 RL Infra 为主线的中文 ML Systems 学习笔记，涵盖 slime、AReaL、verl、OpenRLHF、Agentic RL、训推一致性、权重更新、FSDP/Megatron 训练后端，并延伸到 SGLang 推理系统与 AI Infra 基础 | |

--- a/resources/rl.mdx
+++ b/resources/rl.mdx
@@ -7,7 +7,7 @@ description: "强化学习基础、大模型后训练与强化学习训练系统
 
 | 资源 | 类型 | 简介 | 资料 |
 |------|------|------|------|
-| [强化学习的数学原理](https://www.bilibili.com/video/BV1sd4y167NS/) | 课程 | 西湖大学赵世钰从数学角度讲解强化学习，覆盖贝尔曼方程、值迭代、策略迭代、Monte Carlo、时序差分、Sarsa、Q-learning、值函数近似、策略梯度与 Actor-Critic，并以 Grid World 串联概念和算法。 | [教材 PDF](https://github.com/MathFoundationRL/Book-Mathematical-Foundation-of-Reinforcement-Learning/blob/main/Book-all-in-one.pdf) · [课件](https://github.com/MathFoundationRL/Book-Mathematical-Foundation-of-Reinforcement-Learning/tree/main/Lecture%20slides/slidesContinuouslyUpdated) · [GitHub](https://github.com/MathFoundationRL/Book-Mathematical-Foundation-of-Reinforcement-Learning) |
+| [强化学习的数学原理](https://github.com/MathFoundationRL/Book-Mathematical-Foundation-of-Reinforcement-Learning) | 教材 / 课程 | 西湖大学赵世钰从数学角度讲解强化学习，覆盖贝尔曼方程、值迭代、策略迭代、Monte Carlo、时序差分、Sarsa、Q-learning、值函数近似、策略梯度与 Actor-Critic，并以 Grid World 串联概念和算法。 | [英文教材 PDF](https://github.com/MathFoundationRL/Book-Mathematical-Foundation-of-Reinforcement-Learning/blob/main/Book-all-in-one.pdf) · [中文版（清华大学出版社）](https://www.tup.tsinghua.edu.cn/bookscenter/book_10986001.html) · [课件](https://github.com/MathFoundationRL/Book-Mathematical-Foundation-of-Reinforcement-Learning/tree/main/Lecture%20slides/slidesContinuouslyUpdated) · [中文视频](https://www.bilibili.com/video/BV1sd4y167NS/) |
 | [动手学强化学习](https://hrl.boyuai.com/) | 教程 | 张伟楠、沈键、俞勇编写的中文教程，通过图文和 Jupyter Notebook 实现动态规划、时序差分、DQN、Actor-Critic、PPO、DDPG 与 SAC，并延伸到模仿学习、离线 RL 和多智能体 RL。 | [代码](https://github.com/boyu-ai/Hands-on-RL) · [视频课程](https://www.boyuai.com/elites/course/xVqhU42F5IDky94x) |
 
 ## 大模型强化学习
@@ -21,4 +21,3 @@ description: "强化学习基础、大模型后训练与强化学习训练系统
 | 资源 | 类型 | 简介 | 资料 |
 |------|------|------|------|
 | [Awesome-ML-SYS-Tutorial（中文版）](https://github.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/blob/main/README-cn.md) | 学习笔记合集 | 以 RL Infra 为主线的中文 ML Systems 学习笔记，涵盖 slime、AReaL、verl、OpenRLHF、Agentic RL、训推一致性、权重更新、FSDP/Megatron 训练后端，并延伸到 SGLang 推理系统与 AI Infra 基础 | |
-| [Accio-Lab/Dressage](https://github.com/Accio-Lab/Dressage) | 开源框架 | 基于 slime 的 Agentic RL 训练框架，打通策略 Rollout、Sandbox 工具执行、Token 级轨迹记录和训练样本转换，统一支持 Python 白盒工具循环与 Codex、Claude Code 等 HTTP 黑盒 Agent。 | |

--- a/resources/rl.mdx
+++ b/resources/rl.mdx
@@ -1,7 +1,20 @@
 ---
 title: "RL"
-description: "RLHF、Agentic RL 与强化学习训练系统资源"
+description: "强化学习基础、大模型后训练与强化学习训练系统资源"
 ---
+
+## 强化学习基础
+
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [强化学习的数学原理](https://www.bilibili.com/video/BV1sd4y167NS/) | 课程 | 西湖大学赵世钰从数学角度讲解强化学习，覆盖贝尔曼方程、值迭代、策略迭代、Monte Carlo、时序差分、Sarsa、Q-learning、值函数近似、策略梯度与 Actor-Critic，并以 Grid World 串联概念和算法。 | [教材 PDF](https://github.com/MathFoundationRL/Book-Mathematical-Foundation-of-Reinforcement-Learning/blob/main/Book-all-in-one.pdf) · [课件](https://github.com/MathFoundationRL/Book-Mathematical-Foundation-of-Reinforcement-Learning/tree/main/Lecture%20slides/slidesContinuouslyUpdated) · [GitHub](https://github.com/MathFoundationRL/Book-Mathematical-Foundation-of-Reinforcement-Learning) |
+| [动手学强化学习](https://hrl.boyuai.com/) | 教程 | 张伟楠、沈键、俞勇编写的中文教程，通过图文和 Jupyter Notebook 实现动态规划、时序差分、DQN、Actor-Critic、PPO、DDPG 与 SAC，并延伸到模仿学习、离线 RL 和多智能体 RL。 | [代码](https://github.com/boyu-ai/Hands-on-RL) · [视频课程](https://www.boyuai.com/elites/course/xVqhU42F5IDky94x) |
+
+## 大模型强化学习
+
+| 资源 | 类型 | 简介 | 资料 |
+|------|------|------|------|
+| [Hands-on Modern RL](https://walkinglabs.github.io/hands-on-modern-rl/) | 开源教程 | 以可运行代码串联经典强化学习、大模型后训练与 Agentic RL，覆盖 DQN、Actor-Critic、PPO、RLHF、DPO、GRPO、RLVR、推理模型及工具调用智能体；项目仍在持续更新，仓库提示内容尚未全面审稿。 | [GitHub](https://github.com/walkinglabs/hands-on-modern-rl) · [PDF / EPUB](https://github.com/walkinglabs/hands-on-modern-rl/releases/latest) |
 
 ## RL 系统与基础设施
 


### PR DESCRIPTION
## Summary

- add foundational reinforcement learning and modern LLM RL resources
- consolidate all learning resources on the RL page into one four-column table
- add direct links to the English textbook PDF, the Chinese edition, course slides, videos, code, and downloadable releases
- add a Training page under Open Source Projects
- move Dressage from learning resources to the RL Training project section
- add Dressage quick-start, training-mechanism, and recipe references

## Validation

- verified all new and updated source links
- verified the RL page contains one four-column resource table
- verified the three-column project table schema
- `mint validate`
- `mint broken-links`
- `git diff --check`
- verified `/projects/training` and `/resources/rl` return HTTP 200 in a local Mintlify preview